### PR TITLE
Typos in CONRIBUTING.md and updated repository location

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ be [fork based](https://help.github.com/articles/using-pull-requests/).
 
 ## Documentation
 
-When adding a new model or a new numerical solver, please add a memo describing equations with required differentials and main functionallity. Add memo to [thermopack/doc/memo](https://github.com/SINTEF/thermopack/tree/main/doc/memo).
+When adding a new model or a new numerical solver, please add a memo describing equations with required differentials and main functionallity. Add memo to [thermopack/doc/memo](https://github.com/thermotools/thermopack/tree/main/doc/memo).
 
 ## Code
 
@@ -35,19 +35,19 @@ When submitting code for thermopack, please adhere to the following standards:
 - Add reference to relevant articles in the code. It is sufficient to add author names and digital object identifier (doi). Ex. *Peng and Robinson (10.1021%2Fi160057a011)*
 
 
-New fluids and binary interaction data should be added as new *json* files, or modification to exsisting files, in [thermopack/fluids](https://github.com/SINTEF/thermopack/tree/main/fluids) and [thermopack/binaries](https://github.com/SINTEF/thermopack/main/tree/binaries), and generate compdatadb.f90 and mixdatadb.f90 from the scripts in [thermopack/addon/pyUtils](https://github.com/SINTEF/thermopack/tree/main/pyUtils).
+New fluids and binary interaction data should be added as new *json* files, or modification to exsisting files, in [thermopack/fluids](https://github.com/thermotools/thermopack/tree/main/fluids) and [thermopack/binaries](https://github.com/thermotools/thermopack/main/tree/binaries), and generate compdatadb.f90 and mixdatadb.f90 from the scripts in [thermopack/addon/pyUtils](https://github.com/thermotools/thermopack/tree/main/pyUtils).
 
 Thermopack requires analytical differentials in temperature, volume and mol numbers to second order for the residual Helmholtz energy. New models should include these differentials.
 
 ## Tests
 
-New functionality should be accompanied by unit tests. The test files should be written for pFUnit, a unit testing framework enabling JUnit-like testing of serial and MPI-parallel software written in Fortran. The new tests should be included in [thermopack/unittests](https://github.com/SINTEF/thermopack/tree/main/unittest). The compilation (`make unittest_mode_compiler`) depends on the variable PFUNIT pointing to a working installation of pFUnit.
+New functionality should be accompanied by unit tests. The test files should be written for pFUnit, a unit testing framework enabling JUnit-like testing of serial and MPI-parallel software written in Fortran. The new tests should be included in [thermopack/unittests](https://github.com/thermotools/thermopack/tree/main/unittest). The compilation (`make unittest_mode_compiler`) depends on the variable PFUNIT pointing to a working installation of pFUnit.
 
 The new code need to compile, in debug, optim and openmp mode, and run using the gfortran (Linux) and the Intel FORTRAN (Linux/Windows) compilers. The existing and new unittests should pass when compiled with both gfortran and Intel FORTRAN compiled in debug, optim and opnemp mode. So if possible, new code should have been tested as extensively as possible.
 
-The python interface pycThermopack functionallity should also not be broken. To ensure a working python plugin, please run all example cases in [thermopack/addon/pyExample](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample), and verify that all cases run by running [thermopack/addon/pyExample/run_all_examples.sh](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample/run_all_examples.sh). Also run the exsisting python tests using pytest.
+The python interface pycThermopack functionallity should also not be broken. To ensure a working python plugin, please run all example cases in [thermopack/addon/pyExample](https://github.com/thermotools/thermopack/tree/main/addon/pyExample), and verify that all cases run by running [thermopack/addon/pyExample/run_all_examples.sh](https://github.com/thermotools/thermopack/tree/main/addon/pyExample/run_all_examples.sh). Also run the exsisting python tests using pytest.
 
-If new functionallity is added to pycThermopack, please add new test for the [thermopack/addon/pycThermopack/tests](https://github.com/SINTEF/thermopack/tree/main/addon/pycThermopack/tests)
+If new functionallity is added to pycThermopack, please add new test for the [thermopack/addon/pycThermopack/tests](https://github.com/thermotools/thermopack/tree/main/addon/pycThermopack/tests)
 
 A minimal procedure for testing on Linux would be to execute:
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,16 +15,16 @@ Try to keep new code consistent with the current style of Thermopack.
 
 When submitting code for thermopack, please adhere to the following standards:
 
-- Use 2 space indentaion - no tabs!
+- Use 2 space indentation - no tabs!
 - Write readable code
     - Break lines for readability
-        - Line should ideally not be longer than 80 columns
+        - Lines should ideally not be longer than 80 columns
     - Use comments:
         - For complex code that is difficult to understand
         - Simple code does not need comments
 - Thread safe code:
     - Do not initialize method (function or subroutine) variables at declaration, as this will trigger the SAVE option.
-    - Use of global variables should be avoided, as this is not thread safe. Instead plase all variables in the eos specific containers inheriting the abstract base_eos_param class.
+    - Use of global variables should be avoided, as this is not thread safe. Instead place all variables in the eos specific containers inheriting the abstract base_eos_param class.
 - Use *real* and *integer* and not *real(8)* and *integer(8)* etc. The default real and integer size is defined in the compiler option.
 - Use good variable names
     - The name should indicate what the variable is/does
@@ -35,9 +35,9 @@ When submitting code for thermopack, please adhere to the following standards:
 - Add reference to relevant articles in the code. It is sufficient to add author names and digital object identifier (doi). Ex. *Peng and Robinson (10.1021%2Fi160057a011)*
 
 
-New fluids and binary interaction data should be added as new *json* files, or modification to exsisting files, in [thermopack/fluids](https://github.com/SINTEF/thermopack/tree/main/fluids) and [thermopack/binaries](https://github.com/SINTEF/thermopack/main/tree/binaries), and generate compdatadb.f90 and mixdatadb.f90 form the scripts in [thermopack/addon/pyUtils](https://github.com/SINTEF/thermopack/tree/main/pyUtils).
+New fluids and binary interaction data should be added as new *json* files, or modification to exsisting files, in [thermopack/fluids](https://github.com/SINTEF/thermopack/tree/main/fluids) and [thermopack/binaries](https://github.com/SINTEF/thermopack/main/tree/binaries), and generate compdatadb.f90 and mixdatadb.f90 from the scripts in [thermopack/addon/pyUtils](https://github.com/SINTEF/thermopack/tree/main/pyUtils).
 
-Thermopack reqires analytical differentials in temperature, volume and mol numbers to second order for the residual Helmholtz energy. New models should include these differentials.
+Thermopack requires analytical differentials in temperature, volume and mol numbers to second order for the residual Helmholtz energy. New models should include these differentials.
 
 ## Tests
 
@@ -45,7 +45,7 @@ New functionality should be accompanied by unit tests. The test files should be 
 
 The new code need to compile, in debug, optim and openmp mode, and run using the gfortran (Linux) and the Intel FORTRAN (Linux/Windows) compilers. The existing and new unittests should pass when compiled with both gfortran and Intel FORTRAN compiled in debug, optim and opnemp mode. So if possible, new code should have been tested as extensively as possible.
 
-The python interface pycThermopack functionallity should also not be broken. To ensure a workin python plugin, please run all example cases in [thermopack/addon/pyExample](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample), and verify that all cases run by running [thermopack/addon/pyExample/run_all_examples.sh](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample/run_all_examples.sh). Also run the exsisting python tests using pytest.
+The python interface pycThermopack functionallity should also not be broken. To ensure a working python plugin, please run all example cases in [thermopack/addon/pyExample](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample), and verify that all cases run by running [thermopack/addon/pyExample/run_all_examples.sh](https://github.com/SINTEF/thermopack/tree/main/addon/pyExample/run_all_examples.sh). Also run the exsisting python tests using pytest.
 
 If new functionallity is added to pycThermopack, please add new test for the [thermopack/addon/pycThermopack/tests](https://github.com/SINTEF/thermopack/tree/main/addon/pycThermopack/tests)
 
@@ -62,6 +62,6 @@ cd ../pyExample
 ```
 and to repeat for debug and openmp mode.
 
-###Requirements:
+### Requirements:
 - [pFUnit](https://github.com/Goddard-Fortran-Ecosystem/pFUnit)
 - python pytest

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To compile using Intel FORTRAN, use `make optim_ifort`.
 
 ```bash
 # Fetch and compile
-git clone https://github.com/SINTEF/thermopack.git
+git clone https://github.com/thermotools/thermopack.git
 cd thermopack
 make optim
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ and is dependent on the [LAPACK](http://www.netlib.org/lapack/) and
 [BLAS](http://www.netlib.org/blas/) libraries. On the Windows OS the code can
 be compiled using [Microsoft Visual
 Studio](https://visualstudio.microsoft.com/vs/). A solution file is found in
-[thermopack/MSVStudio](https://github.com/SINTEF/thermopack/tree/main/MSVStudio),
+[thermopack/MSVStudio](https://github.com/thermotools/thermopack/tree/main/MSVStudio),
 assuming that the Intel Fortran compiler is integrated with Microsoft Visual
 Studio.
 
@@ -135,7 +135,7 @@ pacman -S mingw-w64-x86_64-dlfcn
 Open the `MSYS2 MinGW 64-bit` application, and enter the following in the terminal:
 
 ```bash
-git clone https://github.com/SINTEF/thermopack.git
+git clone https://github.com/thermotools/thermopack.git
 cd thermopack
 mingw32-make.exe optim
 ```
@@ -208,7 +208,7 @@ Ailo Aasen (ailo.aasen@sintef.no)<br>
 Øivind Wilhelmsen (oivind.wilhelmsen@sintef.no)
 
 ## License
-Thermopack is distributed under the [MIT license](https://github.com/SINTEF/thermopack/blob/main/LICENSE).
+Thermopack is distributed under the [MIT license](https://github.com/thermotools/thermopack/blob/main/LICENSE).
 
 ## Acknowledgments
 A number of colleagues at SINTEF Energy Research have contributed to the


### PR DESCRIPTION
Although pull-request #59 in SINTEF/thermopack has not been merged yet, I assume https://github.com/thermotools/thermopack.git is now the correct location in README.md.