### PR TITLE
Proposal to change some return values (NB: Breaking changes)

### DIFF
--- a/addon/pycThermopack/pyctp/utils.py
+++ b/addon/pycThermopack/pyctp/utils.py
@@ -43,3 +43,35 @@ def get_contribution_flag(property_flag):
         raise ValueError("property_flag has wrong value."\
                          " Expected I,R or IR, got " + prop_flag)
     return contribution_c
+
+
+class FlashResult:
+    """
+    Object to return the result of a flash calculation
+    """
+    def __init__(self, flash_tuple, flash_type, z, state_tuple, extra_dict=None):
+        self.x, self.y, self.betaV, self.betaL, self.phase_idx = flash_tuple
+        self.phase = 'Must be set after initialization'
+        self.flash_type = flash_type
+        self.state_point = state_tuple
+        self.z = z
+        self.extra_dict = extra_dict
+        if extra_dict is not None:
+            for k, v in extra_dict.items():
+                self.__setattr__(k, v[1])
+
+    def __repr__(self):
+        reprstr = 'Flash result object (attribute identifiers in parentheses) \n'
+        reprstr += 'Flash type : ' + self.flash_type + '\n'
+        reprstr += 'State point : ' + str(self.state_point) + '\n'
+        reprstr += 'Total composition (z) : ' + str(self.z) + '\n'
+        reprstr += 'Phase (phase_idx) : ' + self.phase + ' (' + str(self.phase_idx) + ')\n'
+        reprstr += 'Vapour fraction (betaV) : ' + str(self.betaV) + '\n'
+        reprstr += 'Vapour composition (y) : ' + str(self.y) + '\n'
+        reprstr += 'Liquid fraction (betaL) : ' + str(self.betaL) + '\n'
+        reprstr += 'Liquid composition (x) : ' + str(self.x) + '\n'
+        if self.extra_dict is not None:
+            for k, v in self.extra_dict.items():
+                reprstr += v[0] + ' (' + k + ') : ' + str(v[1]) + '\n'
+        return reprstr
+


### PR DESCRIPTION
I quite often find myself having to double check what the order of return values for flash calculations, phase envelope calculations etc. are. And also double checking the docs on what the different phase identifier keys refer to.

Inspired by scipy's `OptimizeResult` object, I decided to write a `FlashResult` object so that i could more easily extract the information I wanted from a calculation.  I'm considering doing the same for a `PhaseEnvelope` class.

All would be well if this was backwards compatible, but its not :/ and I feel like adding some kwarg that controls the output type will unnecessarily clutter the functions. Additionally, making it backwards compatible by having a kwarg that defaults to the current behaviour makes it less user friendly to use the proposed ''new'' behaviour.

This pull request is initially meant to show what I'm talking about so that we can discuss whether it is something we want to implement. For example usage:

```
from pyctp.cubic import cubic

eos = cubic('C1,NC5', 'SRK')
flsh = eos.two_phase_tpflash(300, 3e5, [0.5, 0.5])
print(flsh)
```

Outputs:

```
Flash result object (attribute identifiers in parentheses) 
Flash type : Tp
State point : (300, 300000.0)
Total composition (z) : [0.5, 0.5]
Phase (phase_idx) : TWO_PHASE (0)
Vapour fraction (betaV) : 0.6653900264011667
Vapour composition (y) : [0.74542239 0.25457761]
Liquid fraction (betaL) : 0.3346099735988333
Liquid composition (x) : [0.01196431 0.98803569]
```

And the attributes are accessed as 

```
x, betaV = flsh.x, flsh.betaV
print(x, betaV) # [0.01196431 0.98803569] 0.6653900264011667
```

The other flashes (that output temperature, etc.) are also handled:

```
eos = cubic('C1,NC5', 'SRK')
flsh = eos.two_phase_uvflash([0.5, 0.5], 1, 10)
print(flsh)
```

Outputs:

```
Flash result object (attribute identifiers in parentheses) 
Flash type : uv
State point : (1, 10)
Total composition (z) : [0.5, 0.5]
Phase (phase_idx) : TWO_PHASE (0)
Vapour fraction (betaV) : 0.7529880007697018
Vapour composition (y) : [0.66401579 0.33598421]
Liquid fraction (betaL) : 0.24701199923029812
Liquid composition (x) : [1.65148325e-05 9.99983485e-01]
Temperature (T) : 184.64193349126222
Pressure (p) : 115.59441004881633
```

where `flsh.T` and `flsh.p` can be used to access the temperature and pressure output.
