### PR TITLE
Fixed bug in FlashResult __getitem__

### DIFF
--- a/addon/pycThermopack/thermopack/utils.py
+++ b/addon/pycThermopack/thermopack/utils.py
@@ -120,7 +120,7 @@ class FlashResult:
             return (_ for _ in self.iterable)
 
     def __getitem__(self, item):
-        return self.iterable[item]
+        return tuple(self.__iter__())[item]
 
     def __repr__(self):
         reprstr = 'FlashResult object for ' + self.flash_type + '-flash\n'


### PR DESCRIPTION
__getitem__ was not correctly excluding variables in order to be backwards compatible as intended. Fixed to return items from the tuple generated from self.__iter__().