### PR TITLE
Fixed alias conflict between WS and  HVWS mixing rules

### DIFF
--- a/src/cbmix.f90
+++ b/src/cbmix.f90
@@ -524,7 +524,7 @@ contains
   subroutine cbCalcAmix(nc, cbeos, t, zcomp)
     use cubic_eos, only: cb_eos, cbMixVdW, cbMixVdWCPA, &
          cbMixHuronVidal, cbMixHuronVidal2, cbMixNRTL, cbMixUNIFAC, &
-         cbMixHVCPA, cbMixHVCPA2, cbMixWongSandler, cbMixWSCPA, cbMixHvWS, cbMixReid
+         cbMixHVCPA, cbMixHVCPA2, cbMixWongSandler, cbMixWSCPA, cbMixHVWongSandler, cbMixReid
     use wong_sandler, only : WongSandlerMix
     use excess_gibbs, only : ExcessGibbsMix
     use cbAlpha, only: cbCalcAlphaTerm
@@ -548,7 +548,7 @@ contains
          cbMixHVCPA, cbMixHVCPA2)
       call ExcessGibbsMix(cbeos,T,zcomp)
 
-   case (cbMixWongSandler, cbMixWSCPA, cbMixHVWS)
+   case (cbMixWongSandler, cbMixWSCPA, cbMixHVWongSandler)
       call WongSandlerMix(cbeos, T, zcomp)
 
     case (cbMixReid) !< Un-symmetric - need to be developed

--- a/src/cbselect.f90
+++ b/src/cbselect.f90
@@ -162,7 +162,7 @@ contains
   !! \author Geir S
   !! \author Morten Hammer
   subroutine SelectMixingRules(nc, comp, cbeos, mrulestr, param_reference, b_exponent)
-    use cubic_eos, only: cb_eos, cbMixUNIFAC, cbMixWongSandler, cbMixWSCPA, cbMixHVWS,cbMixNRTL, isHVmixModel
+    use cubic_eos, only: cb_eos, cbMixUNIFAC, cbMixWongSandler, cbMixWSCPA, cbMixHVWongSandler,cbMixNRTL, isHVmixModel
     use stringmod, only: str_eq
     use compdata, only: gendata_pointer
     use cbmix, only: cbCalcLowcasebij
@@ -186,7 +186,7 @@ contains
        call cbeos%mixGE%excess_gibbs_allocate_and_init(nc)
     end if
 
-    if (cbeos%mruleidx == cbMixWongSandler .or. cbeos%mruleidx == cbMixWSCPA .or. cbeos%mruleidx == cbMixHVWS) then
+    if (cbeos%mruleidx == cbMixWongSandler .or. cbeos%mruleidx == cbMixWSCPA .or. cbeos%mruleidx == cbMixHVWongSandler) then
        !print *, cbeos%mruleidx, isHVmixModel(cbeos%mruleidx)
        call cbeos%mixWS%WS_allocate_and_init(nc)
     endif

--- a/src/cubic_eos.f90
+++ b/src/cubic_eos.f90
@@ -207,7 +207,7 @@ module cubic_eos
   integer, parameter :: cbMixHVCPA2 = 26 !< Huron Vidal mixing rule (classic, but kij from another db)
   integer, parameter :: cbMixWongSandler = 3 !< Wong Sandler mixing rule
   integer, parameter :: cbMixWSCPA = 31 !< Wong-Sandler mixing rule for CPA
-  integer, parameter :: cbMixHVWS = 32 !< Wong-Sandler mixing rule with HV formulation of NRTL
+  integer, parameter :: cbMixHVWongSandler = 32 !< Wong-Sandler mixing rule with HV formulation of NRTL
 
   type mix_label_mapping
     integer :: mix_idx_group
@@ -253,7 +253,7 @@ module cubic_eos
        mix_idx=cbMixWSCPA, short_label="WongSandler", label="WSCPA",&
        alias = ""), &
        mix_label_mapping(mix_idx_group=cbMixWongSandler,&
-       mix_idx=cbMixHVWS, short_label="HVWS", label="HVWS",&
+       mix_idx=cbMixHVWongSandler, short_label="HVWongSandler", label="HVWongSandler",&
        alias = "") &
        /)
 
@@ -264,7 +264,7 @@ module cubic_eos
        cbMixHuronVidal2,&
        cbMixHVCPA,&
        cbMixHVCPA2,&
-       cbMixHVWS/)
+       cbMixHVWongSandler/)
 
   integer, parameter :: nGECorrs = 7
   integer, parameter, dimension(nGECorrs) :: GECorrIndices = (/&


### PR DESCRIPTION
When the alias of a mixing rule is a substring of the short_label of another mixing rule, such as for WS (wong sandler) and HVWS (huron vidal wong sandler), the function get_mix_db_idx is not working as intended. I have changed the naming of the new HVWS mixing rule to avoid the problem, but something should be done with get_mix_db_idx.