### PR TITLE
Changed name of the [set/get]_fluid_param methods of pcsaft

### DIFF
--- a/addon/pycThermopack/thermopack/pcsaft.py
+++ b/addon/pycThermopack/thermopack/pcsaft.py
@@ -10,6 +10,7 @@ from os import path
 from .thermo import c_len_type
 from .saft import saft
 from . import utils
+import warnings
 
 
 class pcsaft(saft):
@@ -48,6 +49,9 @@ class pcsaft(saft):
 
         # Define parameters to be set by init
         self.nc = None
+        self.m = None
+        self.sigma = None
+        self.eps_div_kb = None
 
         if comps is not None:
             self.init(comps, parameter_reference=parameter_reference, simplified=simplified, polar=polar)
@@ -96,8 +100,7 @@ class pcsaft(saft):
         self.sigma = np.zeros(self.nc)
         self.eps_div_kb = np.zeros(self.nc)
         for i in range(self.nc):
-            self.m[i], self.sigma[i], self.eps_div_kb[i], eps, beta = \
-                self.get_pure_params(i+1)
+            self.m[i], self.sigma[i], self.eps_div_kb[i], eps, beta = self.get_pure_fluid_param(i+1)
 
 
     def get_kij(self, c1, c2):
@@ -150,7 +153,7 @@ class pcsaft(saft):
                        byref(kij_c))
 
 
-    def set_pure_params(self, c, m, sigma, eps_div_kb, eps=0.0, beta=0.0):
+    def set_pure_fluid_param(self, c, m, sigma, eps_div_kb, eps=0.0, beta=0.0):
         """Utility
         Set pure fluid PC-SAFT parameters
 
@@ -177,7 +180,23 @@ class pcsaft(saft):
         self.s_set_pure_params(byref(c_c),
                                param_c)
 
-    def get_pure_params(self, c):
+    def set_pure_params(self, c, m, sigma, eps_div_kb, eps=0.0, beta=0.0):
+        """Deprecated
+        Set pure fluid PC-SAFT parameters
+
+        Args:
+            c (int): Component index (FORTRAN)
+            m (float): Mean number of segments
+            sigma (float): Segment diameter (m)
+            eps_div_kb (float): Well depth divided by Boltzmann's constant (K)
+            eps (float): Association energy (J/mol)
+            beta (float): Association volume (-)
+        """
+        warnings.warn("The method 'set_pure_params' has been repaced by 'set_pure_fluid_param', and may be removed in"
+                      "the future.", DeprecationWarning, stacklevel=2)
+        self.set_pure_fluid_param(c, m, sigma, eps_div_kb, eps=eps, beta=beta)
+
+    def get_pure_fluid_param(self, c):
         """Utility
         Get pure fluid PC-SAFT parameters
 
@@ -203,6 +222,22 @@ class pcsaft(saft):
         m, sigma, eps_div_kb, eps, beta = param_c
         return m, sigma, eps_div_kb, eps, beta
 
+    def get_pure_params(self, c):
+        """Deprecated
+        Get pure fluid PC-SAFT parameters
+
+        Args:
+            c (int): Component index (FORTRAN)
+        Returns:
+            m (float): Mean number of segments
+            sigma (float): Segment diameter (m)
+            eps_div_kb (float): Well depth divided by Boltzmann's constant (K)
+            eps (float): Association energy (J/mol)
+            beta (float): Association volume (-)
+        """
+        warnings.warn("The method 'get_pure_params' has been repaced by 'get_pure_fluid_param', and may be removed in"
+                      "the future.", DeprecationWarning, stacklevel=2)
+        self.get_pure_fluid_param(c)
 
     def lng_ii(self, temp, volume, n, i, lng_t=None, lng_v=None, lng_n=None, lng_tt=None, lng_vv=None,
                lng_tv=None, lng_tn=None, lng_vn=None, lng_nn=None):

--- a/addon/pycThermopack/thermopack/saftvrmie.py
+++ b/addon/pycThermopack/thermopack/saftvrmie.py
@@ -82,6 +82,12 @@ class saftvrmie(saft):
         self.nc = None
         self.lambda_a = None
         self.lambda_r = None
+        self.nc = None
+        self.m = None
+        self.sigma = None
+        self.eps_div_kb = None
+        self.lambda_a = None
+        self.lambda_r = None
 
         if comps is not None:
             self.init(comps, parameter_reference=parameter_reference)

--- a/doc/markdown/pcsaft_methods.md
+++ b/doc/markdown/pcsaft_methods.md
@@ -1,5 +1,5 @@
 <!--- 
-Generated at: 2023-05-29T18:38:09.630633
+Generated at: 2023-06-22T15:42:48.988149
 This is an auto-generated file, generated using the script at thermopack/addon/pyUtils/docs/markdown_from_docstrings.py
 The file is created by parsing the docstrings of the methods in the 
 pcsaft class. For instructions on how to use the parser routines, see the
@@ -18,9 +18,12 @@ PC-SAFT Equation of State. This class inherits the `saft` class, which in turn i
   * [Utility methods](#Utility-methods)
     * [association_energy_density](#association_energy_densityself-temp-n_alpha-phiNone-phi_tNone-phi_nNone-phi_ttNone-phi_tnNone-phi_nnNone)
     * [get_kij](#get_kijself-c1-c2)
-    * [get_pure_params](#get_pure_paramsself-c)
+    * [get_pure_fluid_param](#get_pure_fluid_paramself-c)
     * [lng_ii](#lng_iiself-temp-volume-n-i-lng_tNone-lng_vNone-lng_nNone-lng_ttNone-lng_vvNone-lng_tvNone-lng_tnNone-lng_vnNone-lng_nnNone)
     * [set_kij](#set_kijself-c1-c2-kij)
+    * [set_pure_fluid_param](#set_pure_fluid_paramself-c-m-sigma-eps_div_kb-eps00-beta00)
+  * [Deprecated methods](#Deprecated-methods)
+    * [get_pure_params](#get_pure_paramsself-c)
     * [set_pure_params](#set_pure_paramsself-c-m-sigma-eps_div_kb-eps00-beta00)
 
 ## Constructor
@@ -87,10 +90,10 @@ Set- and get methods for interaction parameters and pure fluid parameters.
   * [Utility methods](#Utility-methods)
     * [association_energy_density](#association_energy_densityself-temp-n_alpha-phiNone-phi_tNone-phi_nNone-phi_ttNone-phi_tnNone-phi_nnNone)
     * [get_kij](#get_kijself-c1-c2)
-    * [get_pure_params](#get_pure_paramsself-c)
+    * [get_pure_fluid_param](#get_pure_fluid_paramself-c)
     * [lng_ii](#lng_iiself-temp-volume-n-i-lng_tNone-lng_vNone-lng_nNone-lng_ttNone-lng_vvNone-lng_tvNone-lng_tnNone-lng_vnNone-lng_nnNone)
     * [set_kij](#set_kijself-c1-c2-kij)
-    * [set_pure_params](#set_pure_paramsself-c-m-sigma-eps_div_kb-eps00-beta00)
+    * [set_pure_fluid_param](#set_pure_fluid_paramself-c-m-sigma-eps_div_kb-eps00-beta00)
 
 
 ### `association_energy_density(self, temp, n_alpha, phi=None, phi_t=None, phi_n=None, phi_tt=None, phi_tn=None, phi_nn=None)`
@@ -161,7 +164,7 @@ Get binary well depth interaction parameter
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; 
 
-### `get_pure_params(self, c)`
+### `get_pure_fluid_param(self, c)`
 Get pure fluid PC-SAFT parameters
 
 #### Args:
@@ -279,6 +282,80 @@ Set binary well depth interaction parameter
 &nbsp;&nbsp;&nbsp;&nbsp; **kij (float):** 
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Well depth interaction parameter
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; 
+
+### `set_pure_fluid_param(self, c, m, sigma, eps_div_kb, eps=0.0, beta=0.0)`
+Set pure fluid PC-SAFT parameters
+
+#### Args:
+
+&nbsp;&nbsp;&nbsp;&nbsp; **c (int):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Component index (FORTRAN)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **m (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Mean number of segments
+
+&nbsp;&nbsp;&nbsp;&nbsp; **sigma (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Segment diameter (m)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **eps_div_kb (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Well depth divided by Boltzmann's constant (K)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **eps (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Association energy (J/mol)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **beta (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Association volume (-)
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; 
+
+## Deprecated methods
+
+Deprecated methods are not maintained, and may be removed in the future.
+
+### Table of contents
+  * [Deprecated methods](#Deprecated-methods)
+    * [get_pure_params](#get_pure_paramsself-c)
+    * [set_pure_params](#set_pure_paramsself-c-m-sigma-eps_div_kb-eps00-beta00)
+
+
+### `get_pure_params(self, c)`
+Get pure fluid PC-SAFT parameters
+
+#### Args:
+
+&nbsp;&nbsp;&nbsp;&nbsp; **c (int):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Component index (FORTRAN)
+
+#### Returns:
+
+&nbsp;&nbsp;&nbsp;&nbsp; **m (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Mean number of segments
+
+&nbsp;&nbsp;&nbsp;&nbsp; **sigma (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Segment diameter (m)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **eps_div_kb (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Well depth divided by Boltzmann's constant (K)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **eps (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Association energy (J/mol)
+
+&nbsp;&nbsp;&nbsp;&nbsp; **beta (float):** 
+
+&nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp;  Association volume (-)
 
 &nbsp;&nbsp;&nbsp;&nbsp; &nbsp;&nbsp;&nbsp;&nbsp; 
 


### PR DESCRIPTION
The names of the methods are now equivalent to the names in saftvrmie.

This makes it easier to write code that is "saft-variant agnostic". Kept the old set/get methods, but they now raise a DeprecationWarning (so this doesn't break any existing code).