### PR TITLE
PC-SAFT Krypton parameters

### DIFF
--- a/doc/markdown/Component-name-mapping.md
+++ b/doc/markdown/Component-name-mapping.md
@@ -1,6 +1,6 @@
 <!---
 This is an auto-generated file, written by the module at addon/pyUtils/compdatadb.py
-Generated at : 2023-08-17T16:32:08.374065
+Generated at : 2023-09-04T12:16:57.143846
 This is the same module that is used to generate the Fortran
 component database files.
 --->
@@ -68,7 +68,7 @@ In order to specify fluids in Thermopack you need to use fluid identifiers as sh
 | Hydrogen | H2 | :heavy_check_mark: |   |   |
 | Isobutane | IC4 |   | :heavy_check_mark: |   |
 | Isopentane | IC5 |   | :heavy_check_mark: |   |
-| Krypton | KR | :heavy_check_mark: |   |   |
+| Krypton | KR | :heavy_check_mark: | :heavy_check_mark: |   |
 | Lennard-jones_fluid | LJF | :heavy_check_mark: |   |   |
 | Methane | C1 | :heavy_check_mark: | :heavy_check_mark: |   |
 | Methanol | MEOH | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |

--- a/fluids/Krypton.json
+++ b/fluids/Krypton.json
@@ -142,6 +142,16 @@
   },
   "SRK": {},
   "PR": {},
+  "PC-SAFT-1": {
+  "m": 1.0,
+  "sigma": 3.63E-10,
+  "eps_depth_divk": 163.1,
+  "eps": 0.0,
+  "beta": 0.0,
+  "assoc_scheme": "None",
+  "bib_reference": "Sauer & Gross (2017). DOI: 10.1021/acs.iecr.6b04551",
+  "ref": "Default/Sauer_Gross_2017"
+  },
   "SAFTVRMIE-1": {
     "m": 1.000,
     "sigma": 3.6400E-10,

--- a/src/pc_saft_datadb.f90
+++ b/src/pc_saft_datadb.f90
@@ -1,6 +1,6 @@
 !> Automatically generated to file pc_saft_datadb.f90
 !! using utility python code pyUtils
-!! Time stamp: 2023-08-17T16:34:47.659827
+!! Time stamp: 2023-09-04T12:06:02.838805
 
 module pc_saft_datadb
   use thermopack_constants, only: uid_len, ref_len, bibref_len
@@ -585,6 +585,21 @@ module pc_saft_datadb
 
   type(pc_saft_data), parameter :: PCcx37 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
+      compName = "KR", &
+      m = 1., &
+      sigma = 3.63e-10, &
+      eps_depth_divk = 163.1, &
+      eps = 0., &
+      beta = 0., &
+      assoc_scheme = no_assoc, &
+      mu = 0., &
+      Q = 0., &
+      bib_ref = "Sauer & Gross (2017). DOI: 10.1021/acs.iecr.6b04551", &
+      ref = "Default/Sauer_Gross_2017" &
+      )
+
+  type(pc_saft_data), parameter :: PCcx38 = &
+      pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "C1", &
       m = 1., &
       sigma = 3.7039e-10, &
@@ -598,7 +613,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx38 = &
+  type(pc_saft_data), parameter :: PCcx39 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "MEOH", &
       m = 2.1, &
@@ -613,7 +628,7 @@ module pc_saft_datadb
       ref = "Default/deVilliers2011" &
       )
 
-  type(pc_saft_data), parameter :: PCcx39 = &
+  type(pc_saft_data), parameter :: PCcx40 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "N2", &
       m = 1.2053, &
@@ -628,7 +643,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx40 = &
+  type(pc_saft_data), parameter :: PCcx41 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "N2", &
       m = 1.1504, &
@@ -643,7 +658,7 @@ module pc_saft_datadb
       ref = "Gross2005" &
       )
 
-  type(pc_saft_data), parameter :: PCcx41 = &
+  type(pc_saft_data), parameter :: PCcx42 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "N2", &
       m = 1.1879, &
@@ -658,7 +673,7 @@ module pc_saft_datadb
       ref = "Gross2005ADJQ" &
       )
 
-  type(pc_saft_data), parameter :: PCcx42 = &
+  type(pc_saft_data), parameter :: PCcx43 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "O2", &
       m = 1.1217, &
@@ -673,7 +688,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx43 = &
+  type(pc_saft_data), parameter :: PCcx44 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "C3", &
       m = 2.002, &
@@ -688,7 +703,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx44 = &
+  type(pc_saft_data), parameter :: PCcx45 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "TOLU", &
       m = 2.8149, &
@@ -703,7 +718,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx45 = &
+  type(pc_saft_data), parameter :: PCcx46 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "H2O", &
       m = 1.5, &
@@ -718,7 +733,7 @@ module pc_saft_datadb
       ref = "Default/Grenner2006" &
       )
 
-  type(pc_saft_data), parameter :: PCcx46 = &
+  type(pc_saft_data), parameter :: PCcx47 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "H2O", &
       m = 1.0656, &
@@ -733,7 +748,7 @@ module pc_saft_datadb
       ref = "Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx47 = &
+  type(pc_saft_data), parameter :: PCcx48 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC4", &
       m = 2.3316, &
@@ -748,7 +763,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx48 = &
+  type(pc_saft_data), parameter :: PCcx49 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC10", &
       m = 4.6627, &
@@ -763,7 +778,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx49 = &
+  type(pc_saft_data), parameter :: PCcx50 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC22", &
       m = 8.7068, &
@@ -778,7 +793,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx50 = &
+  type(pc_saft_data), parameter :: PCcx51 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC12", &
       m = 5.2133, &
@@ -793,7 +808,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx51 = &
+  type(pc_saft_data), parameter :: PCcx52 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC20", &
       m = 8.0081, &
@@ -808,7 +823,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx52 = &
+  type(pc_saft_data), parameter :: PCcx53 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC21", &
       m = 8.3574, &
@@ -823,7 +838,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx53 = &
+  type(pc_saft_data), parameter :: PCcx54 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC17", &
       m = 6.96, &
@@ -838,7 +853,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx54 = &
+  type(pc_saft_data), parameter :: PCcx55 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC7", &
       m = 3.4831, &
@@ -853,7 +868,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx55 = &
+  type(pc_saft_data), parameter :: PCcx56 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC16", &
       m = 6.6107, &
@@ -868,7 +883,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx56 = &
+  type(pc_saft_data), parameter :: PCcx57 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC6", &
       m = 3.0576, &
@@ -883,7 +898,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx57 = &
+  type(pc_saft_data), parameter :: PCcx58 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC19", &
       m = 7.6587, &
@@ -898,7 +913,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx58 = &
+  type(pc_saft_data), parameter :: PCcx59 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC9", &
       m = 4.2079, &
@@ -913,7 +928,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx59 = &
+  type(pc_saft_data), parameter :: PCcx60 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC18", &
       m = 7.3094, &
@@ -928,7 +943,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx60 = &
+  type(pc_saft_data), parameter :: PCcx61 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC8", &
       m = 3.8176, &
@@ -943,7 +958,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx61 = &
+  type(pc_saft_data), parameter :: PCcx62 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC25", &
       m = 9.7548, &
@@ -958,7 +973,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx62 = &
+  type(pc_saft_data), parameter :: PCcx63 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC15", &
       m = 6.2614, &
@@ -973,7 +988,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx63 = &
+  type(pc_saft_data), parameter :: PCcx64 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC5", &
       m = 2.6896, &
@@ -988,7 +1003,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx64 = &
+  type(pc_saft_data), parameter :: PCcx65 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC14", &
       m = 5.912, &
@@ -1003,7 +1018,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx65 = &
+  type(pc_saft_data), parameter :: PCcx66 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC24", &
       m = 9.4055, &
@@ -1018,7 +1033,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx66 = &
+  type(pc_saft_data), parameter :: PCcx67 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC23", &
       m = 9.0561, &
@@ -1033,7 +1048,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx67 = &
+  type(pc_saft_data), parameter :: PCcx68 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC13", &
       m = 5.5627, &
@@ -1048,7 +1063,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  type(pc_saft_data), parameter :: PCcx68 = &
+  type(pc_saft_data), parameter :: PCcx69 = &
       pc_saft_data(eosidx = eosPC_SAFT, &
       compName = "NC11", &
       m = 4.864, &
@@ -1063,7 +1078,7 @@ module pc_saft_datadb
       ref = "Default/Kontogeorgis_Folas2001" &
       )
 
-  integer, parameter :: nPCmodels = 68
+  integer, parameter :: nPCmodels = 69
   type(pc_saft_data), dimension(nPCmodels), parameter :: PCarray = (/&
       PCcx1,PCcx2,PCcx3,PCcx4,PCcx5, &
       PCcx6,PCcx7,PCcx8,PCcx9,PCcx10, &
@@ -1078,7 +1093,7 @@ module pc_saft_datadb
       PCcx51,PCcx52,PCcx53,PCcx54,PCcx55, &
       PCcx56,PCcx57,PCcx58,PCcx59,PCcx60, &
       PCcx61,PCcx62,PCcx63,PCcx64,PCcx65, &
-      PCcx66,PCcx67,PCcx68 &
+      PCcx66,PCcx67,PCcx68,PCcx69 &
   /)
 
   type (PCkijdata), parameter :: PCSAFT_KIJ_1 = &


### PR DESCRIPTION
Added Krypton parameters for PC-SAFT. Parameters from Sauer & Gross, Classical Density Functional Theory for Liquid−Fluid Interfaces and Confined Systems: A Functional for the Perturbed-Chain Polar Statistical Associating Fluid Theory Equation of State (2017).