### PR TITLE
Introduce robustness flag.

### DIFF
--- a/addon/pyUtils/exports/export_list.py
+++ b/addon/pyUtils/exports/export_list.py
@@ -309,6 +309,8 @@ append_export("speed_of_sound_tv", "speed_of_sound")
 
 append_export("guessphase", "thermo_utils")
 
+append_export("set_numerical_robustness_level", "thermopack_var")
+append_export("get_numerical_robustness_level", "thermopack_var")
 append_export("get_rgas", "thermopack_var")
 append_export("set_tmin", "thermopack_var")
 append_export("get_tmin", "thermopack_var")

--- a/addon/pycThermopack/thermopack/multiparameter.py
+++ b/addon/pycThermopack/thermopack/multiparameter.py
@@ -72,3 +72,6 @@ class multiparam(thermo):
                                             ref_state_len)
 
         self.nc = max(len(comps.split(" ")), len(comps.split(",")))
+
+        if "MEOS" == eos.upper():
+            self.set_numerical_robustness_level(level=1)

--- a/addon/pycThermopack/thermopack/thermo.py
+++ b/addon/pycThermopack/thermopack/thermo.py
@@ -80,6 +80,8 @@ class thermo(object):
         self.s_get_rgas = getattr(
             self.tp, self.get_export_name("thermopack_var", "get_rgas"))
         self.nc = None
+        self.s_get_numerical_robustness_level = getattr(
+            self.tp, self.get_export_name("thermopack_var", "get_numerical_robustness_level"))
         self.s_set_numerical_robustness_level = getattr(
             self.tp, self.get_export_name("thermopack_var", "set_numerical_robustness_level"))
         self.s_get_tmin = getattr(
@@ -919,6 +921,20 @@ class thermo(object):
         self.s_set_numerical_robustness_level.argtypes = [POINTER(c_int)]
         self.s_set_numerical_robustness_level.restype = None
         self.s_set_numerical_robustness_level(byref(level_c))
+
+    def get_numerical_robustness_level(self):
+        """Utility
+        Get numerical robustness level in Thermopack, where 0 is the default
+        and higher levels increase robustness.
+        
+        Returns:
+            level (integer): robustness_level
+        """
+        self.activate()
+        self.s_get_numerical_robustness_level.argtypes = []
+        self.s_get_numerical_robustness_level.restype = c_int
+        level = self.s_get_numerical_robustness_level()
+        return level
 
     def set_tmin(self, temp):
         """Utility

--- a/addon/pycThermopack/thermopack/thermo.py
+++ b/addon/pycThermopack/thermopack/thermo.py
@@ -80,6 +80,8 @@ class thermo(object):
         self.s_get_rgas = getattr(
             self.tp, self.get_export_name("thermopack_var", "get_rgas"))
         self.nc = None
+        self.s_set_numerical_robustness_level = getattr(
+            self.tp, self.get_export_name("thermopack_var", "set_numerical_robustness_level"))
         self.s_get_tmin = getattr(
             self.tp, self.get_export_name("thermopack_var", "get_tmin"))
         self.s_set_tmin = getattr(
@@ -903,6 +905,20 @@ class thermo(object):
         self.s_get_rgas.restype = c_double
         rgas = self.s_get_rgas()
         return rgas
+
+    def set_numerical_robustness_level(self, level):
+        """Utility
+        Set numerical robustness level in Thermopack, where 0 is the default
+        and higher levels increase robustness.
+        
+        Args:
+            level (integer): robustness_level
+        """
+        self.activate()
+        level_c = c_int(level)
+        self.s_set_numerical_robustness_level.argtypes = [POINTER(c_int)]
+        self.s_set_numerical_robustness_level.restype = None
+        self.s_set_numerical_robustness_level(byref(level_c))
 
     def set_tmin(self, temp):
         """Utility

--- a/src/eos_container.f90
+++ b/src/eos_container.f90
@@ -233,7 +233,8 @@ end module eos_container
 subroutine update_global_variables_form_active_thermo_model()
   use thermopack_var, only: nc, nph, complist, apparent, nce, &
        ncsym, numAssocSites, get_active_thermo_model, &
-       thermo_model, Rgas, kRgas, tpTmax, tpTmin, tpPmax, tpPmin
+       thermo_model, Rgas, kRgas, tpTmax, tpTmin, tpPmax, tpPmin, &
+       robustness_level
   use saftvrmie_containers, only: saftvrmie_eos, saftvrmie_param, svrm_opt
   use lj_splined, only: ljs_wca_eos
   implicit none
@@ -249,6 +250,7 @@ subroutine update_global_variables_form_active_thermo_model()
   tpTmin = act_mod_ptr%tpTmin
   tpPmax = act_mod_ptr%tpPmax
   tpPmin = act_mod_ptr%tpPmin
+  robustness_level = act_mod_ptr%robustness_level
   if (associated(apparent)) then
     nce = apparent%nce
     ncsym = apparent%ncsym

--- a/src/thermopack_var.f90
+++ b/src/thermopack_var.f90
@@ -159,13 +159,19 @@ module thermopack_var
   public :: set_tmin, get_tmin, set_tmax, get_tmax
   public :: set_pmin, get_pmin, set_pmax, get_pmax
   public :: get_rgas
+  public :: get_numerical_robustness_level, set_numerical_robustness_level
 
 contains
 
   subroutine set_numerical_robustness_level(level)
     integer, intent(in) :: level
     robustness_level = level
-  end subroutine
+  end subroutine set_numerical_robustness_level
+
+  function get_numerical_robustness_level() result(level)
+    integer :: level
+    level = robustness_level
+  end function get_numerical_robustness_level
 
   function get_active_thermo_model() result(p_eos)
     type(thermo_model), pointer :: p_eos

--- a/src/thermopack_var.f90
+++ b/src/thermopack_var.f90
@@ -103,6 +103,8 @@ module thermopack_var
     integer :: eosidx=0
     character(len=label_len) :: label
     integer :: liq_vap_discr_method=PSEUDO_CRIT_MOLAR_VOLUME
+    !> Robustness level: increase to maximize numerical robustness.
+    integer :: robustness_level = 0
 
     !< Gas constant usde by current model
     real :: Rgas = Rgas_default !< J/mol/K
@@ -165,12 +167,19 @@ contains
 
   subroutine set_numerical_robustness_level(level)
     integer, intent(in) :: level
+    ! Locals
+    type(thermo_model), pointer :: p_eos
+    p_eos => get_active_thermo_model()
+    p_eos%robustness_level = level
     robustness_level = level
   end subroutine set_numerical_robustness_level
 
   function get_numerical_robustness_level() result(level)
     integer :: level
-    level = robustness_level
+    ! Locals
+    type(thermo_model), pointer :: p_eos
+    p_eos => get_active_thermo_model()
+    level = p_eos%robustness_level
   end function get_numerical_robustness_level
 
   function get_active_thermo_model() result(p_eos)

--- a/src/thermopack_var.f90
+++ b/src/thermopack_var.f90
@@ -32,6 +32,8 @@ module thermopack_var
   integer :: ncsym = 0
   !< Total number of associating sites.
   integer :: numAssocSites = 0
+  !> Robustness level: increase to maximize numerical robustness.
+  integer :: robustness_level = 0
 
   !> List of component names
   character (len=eosid_len), pointer :: complist(:)
@@ -159,6 +161,11 @@ module thermopack_var
   public :: get_rgas
 
 contains
+
+  subroutine set_numerical_robustness_level(level)
+    integer, intent(in) :: level
+    robustness_level = level
+  end subroutine
 
   function get_active_thermo_model() result(p_eos)
     type(thermo_model), pointer :: p_eos

--- a/src/tp_solver.f90
+++ b/src/tp_solver.f90
@@ -10,7 +10,7 @@ module tp_solver
   !
   use numconstants, only: machine_prec, small
   use thermopack_constants
-  use thermopack_var, only: nc
+  use thermopack_var, only: nc, robustness_level
   use eos
   use thermo_utils, only: wilsonK, phase_Is_fake
   use stability, only : stabcalc, stabilityLimit
@@ -150,7 +150,7 @@ contains
         valid_beta = (beta > 0.0 .and. beta < 1.0)
       endif
       do_stability_check = ((((.not. found_smaller_g) .OR. (.not. valid_beta)) .and. iter == dem_acc_freq)&
-                           .or. (.not. rr_has_solution))
+                           .or. (.not. rr_has_solution) .or. robustness_level>=1)
       if (do_stability_check) then
         if (.not. stab_analysis_done) then ! Have we restarted already?
           if (verbose) then


### PR DESCRIPTION
TP flash routines for MEOS are very unstable if one skips stability check after successive substitutions. Since one often wants robustness over speed, I introduced a flag to control this. The idea would be to use this flag across modules.