### PR TITLE
Updated cpp interface

### DIFF
--- a/include/README.md
+++ b/include/README.md
@@ -1,0 +1,28 @@
+# ThermoPack C/C++ interface
+
+ThermoPack can be interfaced from C/C++ using the header file `thermopack.h` in this directory. The file `test.cpp` and 
+`Makefile` in the `test_includes` directory serve as a minimal example of how to link ThermoPack to a C program.
+
+To build the test file (`test.cpp`) navigate to the top-level thermopack directory (the one above this directory), and
+run the commands
+
+```
+make [optim/debug]
+cd include/test_includes/
+make
+```
+
+The first command will build the thermopack library, which is placed in the `bin` directory. The second `make` command 
+compiles `test.cpp` and links to the thermopack library. The options `optim/debug` are used to toggle debug flags off/on.
+
+
+# If something goes wrong
+
+* The path to your Fortran and C compiler are set in the top of the `Makefile`, in the variables `FC` and `CC`. Modify these
+as needed.
+* If you get the error message: `ld: Assertion failed: (_file->_atomsArrayCount == computedAtomCount && "more atoms allocated than expected"), function parse, file macho_relocatable_file.cpp, line 2061.`
+  * You may be using a Mac, and may need to update `Xcode` command line tools, as there appears to be a bug in a specific version.
+    * See [here](https://github.com/iains/gcc-12-branch/issues/6#issuecomment-1260282797) for more info on the bug.
+  * See [here](https://stackoverflow.com/questions/15417619/how-do-you-update-xcode-on-osx-to-the-latest-version) for info
+on updating `Xcode`.
+* If none of the above solve the problem, please feel free to leave an Issue.

--- a/include/test_includes/Makefile
+++ b/include/test_includes/Makefile
@@ -1,28 +1,29 @@
 CC=g++
 FC=gfortran
 DEF=
-LTP=-lthermopack_debug_gfortran_Linux
+UNAME := $(shell uname 2>/dev/null || echo Unknown)
+LTP=-lthermopack_debug_gfortran_$(UNAME)
 LIBS=$(LTP) -llapack -lblas -lstdc++
 
-CFLAGS=-fPIC -cpp -Wall -g -mieee-fp -fsignaling-nans
-CFLAGS_RELEASE=-fPIC -cpp -O3 -mieee-fp -fsignaling-nans
+CFLAGS=-fPIC -cpp -Wall -g -fsignaling-nans
+CFLAGS_RELEASE=-fPIC -cpp -O3 -fsignaling-nans
 
 test: test.o
 	$(FC) $(MAIN) test.o -o test -L../../bin $(LIBS)
 
 release-test:
 	$(MAKE) CFLAGS="$(CFLAGS_RELEASE)" \
-	LTP=-lthermopack_optim_gfortran_Linux test
+	LTP=-lthermopack_optim_gfortran_$(UNAME) test
 
 ifort-test:
 	$(MAKE) test FC=ifort DEF=-D__INTEL_THERMOPACK__ \
 	MAIN=-nofor_main \
-	LTP=-lthermopack_debug_ifort_Linux
+	LTP=-lthermopack_debug_ifort_$(UNAME)
 
 release-ifort-test:
 	$(MAKE) FC=ifort CFLAGS="$(CFLAGS_RELEASE)" \
 	DEF=-D__INTEL_THERMOPACK__ MAIN=-nofor_main \
-	LTP=-lthermopack_optim_ifort_Linux \
+	LTP=-lthermopack_optim_ifort_$(UNAME) \
 	test
 
 clean:

--- a/include/test_includes/test.cpp
+++ b/include/test_includes/test.cpp
@@ -30,9 +30,8 @@ int main() {
     std::cout << "\nInit of SRK\n";
     ISO_C_METHOD(thermopack_init_c)("SRK", "Classic",
 				    "Classic", "CO2,N2,C1",
-				    &nph, NULL, NULL, NULL,
-				    NULL, NULL, NULL, NULL);
-
+				    &nph, NULL,"", "", "",
+				    "", "",NULL);
 
     std::cout << "\nConstants\n";
     TMIN = 100.0;
@@ -77,7 +76,7 @@ int main() {
     double Pg(0.0);
     ISO_C_METHOD(thermopack_pressure_c)(&T, &vg, &y[0], &Pg);
     std::cout << "Pg=" << Pg << std::endl;
-    double Pl = MODULE_METHOD(eostv, pressure)(&T, &vl,&x[0], NULL, NULL, NULL, NULL, NULL);
+    double Pl = MODULE_METHOD(eostv, pressure)(&T, &vl, &x[0], NULL, NULL, NULL, NULL, NULL);
     std::cout << "Pl=" << Pl << std::endl;
 
     std::cout << "\nCompressibillit factor\n";

--- a/include/thermopack.h
+++ b/include/thermopack.h
@@ -33,7 +33,7 @@ extern "C" {
   void ISO_C_METHOD(thermopack_init_c)(const char* eos, const char* mixing,
 				       const char* alpha, const char* comp_string,
 				       int* nphases,
-				       /*Optionals, set to NULL if not available: */
+				       /*Optionals, set to NULL (int/double) and "" (const char*) if not available: */
 				       int* liq_vap_discr_method_in,
 				       const char* csp_eos, const char* csp_ref_comp,
 				       const char* kij_ref, const char* alpha_ref,
@@ -128,17 +128,16 @@ extern "C" {
 					/*Optionals, set to NULL if undesired: */
 					const double* dpdv,
 					const double* dpdt, const double* d2pdv2,
-					const double dpdn[], const int* recalculate);
+					const double dpdn[], const int* contribution);
 
   //---------------------------------------------------------------------//
   // Module parameters/variables
   //---------------------------------------------------------------------//
-
-#define RGAS MODULE_METHOD(thermopack_constants, rgas)
-  extern double RGAS;
-#define TMAX MODULE_METHOD(thermopack_constants, tptmax)
+  #define RGAS MODULE_METHOD(thermopack_var, rgas)
+    extern double RGAS;
+  #define TMAX MODULE_METHOD(thermopack_var, tptmax)
     extern double TMAX;
-#define TMIN MODULE_METHOD(thermopack_constants, tptmin)
+  #define TMIN MODULE_METHOD(thermopack_var, tptmin)
     extern double TMIN;
 
 #endif ///*thermopack_h_included */


### PR DESCRIPTION
- Correcting cpp interface defintitions
- Use const char* of zero length for dummy character arguments
- Adapt Makefile for MacOS
