### PR TITLE
Expand Property struct with optional extra values, make construction of Differential struct more flexible

### DIFF
--- a/addon/pycThermopack/thermopack/thermo.py
+++ b/addon/pycThermopack/thermopack/thermo.py
@@ -1312,23 +1312,24 @@ class thermo(object):
                           metaExtremum_c,
                           v_c)
 
-        return_tuple = (np.array(lnfug_c), )
+        diffs = utils.Differentials('tpn')
         if not dlnfugdt is None:
-            return_tuple += (np.array(dlnfugdt_c), )
+            diffs.dT = np.array(dlnfugdt_c)
         if not dlnfugdp is None:
-            return_tuple += (np.array(dlnfugdp_c), )
+            diffs.dp = np.array(dlnfugdp_c)
         if not dlnfugdn is None:
             dlnfugdn_r = np.zeros((len(x), len(x)))
             for i in range(len(x)):
                 for j in range(len(x)):
                     dlnfugdn_r[i][j] = dlnfugdn_c[i+j*len(x)]
-            return_tuple += (dlnfugdn_r, )
+            diffs.dn = dlnfugdn_r
+        diffs.make_v2_compatible()
+        prop = utils.Property(np.array(lnfug_c), diffs)
         if not ophase is None:
-            return_tuple += (ophase_c[0], )
+            prop.ophase = ophase_c[0]
         if not v is None:
-            return_tuple += (v_c[0], )
+            prop.v = v_c[0]
 
-        prop = utils.Property.from_return_tuple(return_tuple, (dlnfugdt, dlnfugdp, dlnfugdn), 'tpn')
         return prop.unpack()
 
     def enthalpy(self, temp, press, x, phase, dhdt=None, dhdp=None, dhdn=None, residual=False):
@@ -2771,7 +2772,7 @@ class thermo(object):
         prop = utils.Property.from_return_tuple(return_tuple, (dhdt, dhdp, dhdn), 'tpn')
         return prop.unpack()
 
-    def thermo_tvp(self, temp, v, n, phase, dlnfugdt=None, dlnfugdp=None,
+    def thermo_tvp(self, temp, v, n, phase=None, dlnfugdt=None, dlnfugdp=None,
                    dlnfugdn=None):
         """TVp-property
         Calculate logarithm of fugacity coefficient given molar numbers,
@@ -2783,6 +2784,7 @@ class thermo(object):
             temp (float): Temperature (K)
             v (float): Volume (m3)
             n (array_like): Molar numbers (mol)
+            phase (Any) : Not in use, may be removed in the future.
             dlnfugdt (logical, optional): Calculate fugacity coefficient differentials with respect to temperature while pressure and composition are held constant. Defaults to None.
             dlnfugdp (logical, optional): Calculate fugacity coefficient differentials with respect to pressure while temperature and composition are held constant. Defaults to None.
             dlnfugdn (logical, optional): Calculate fugacity coefficient differentials with respect to mol numbers while pressure and temperature are held constant. Defaults to None.

--- a/addon/pycThermopack/thermopack/utils.py
+++ b/addon/pycThermopack/thermopack/utils.py
@@ -172,13 +172,15 @@ class Differentials:
     """
     Holder struct for differentials, implements some methods to be as backwards compatible as possible.
     """
-    def __init__(self, diffs, variables):
+    def __init__(self, variables, diffs=None):
         """Constructor
 
         Args:
-            diffs (tuple) : (all three) differentials
             variables (str) : Key (either 'tvn' or 'tpn') indicating what variables are held constant, and what
                             differentials are found in the tuple 'diffs'.
+            diffs (tuple or None) : (all three) differentials, or None. Note: If initialized with None, self.make_v2_compatible()
+                                    must be called after differentials have been set in order for the struct to be
+                                    v2-compatible.
         """
         self.dT = None
         self.dp = None
@@ -187,20 +189,36 @@ class Differentials:
 
         self.iterable = tuple()
         self.constant = variables
-        if variables == 'tvn':
+
+        if (self.constant == 'tvn') and (diffs is not None):
             self.dT, self.dV, self.dn = diffs
+        elif (self.constant == 'tpn') and (diffs is not None):
+            self.dT, self.dp, self.dn = diffs
+        elif diffs is not None:
+            raise KeyError(f'Invalid differential variables key : "{variables}"')
+        self.make_v2_compatible()
+
+    def make_v2_compatible(self):
+        """
+        Needed for backward compatibility, if any differentials are set after init, i.e.
+            diffs = Differentials('tvn')
+            diffs.dT = ...
+            diffs.dn = ...
+        we need to call
+            diffs.init_iterable()
+        after setting all the variables we want, to create the v2-compatible iterables. See thermo.py::thermo for example
+        usage.
+        """
+        if self.constant == 'tvn':
             for d in (self.dT, self.dV, self.dn):
                 if d is not None:
                     self.iterable += (d,)
 
-        elif variables == 'tpn':
-            self.dT, self.dp, self.dn = diffs
+        elif self.constant == 'tpn':
             self.iterable = tuple()
             for d in (self.dT, self.dp, self.dn):
                 if d is not None:
                     self.iterable += (d,)
-        else:
-            raise KeyError(f'Invalid differential variables key : "{variables}"')
 
     @staticmethod
     def from_return_tuple(vals, flags, variables):
@@ -240,7 +258,7 @@ class Differentials:
         else:
             raise KeyError(f'Invalid differential variables key : "{variables}"')
 
-        return Differentials(diffs, variables)
+        return Differentials(variables, diffs)
 
     def __repr__(self):
         ostr = 'Differentials object containing the attributes (description / name / value)\n'
@@ -267,28 +285,40 @@ class Differentials:
 
 class Property:
     """
-    Holder struct to return a property and its derivatives
+    Holder struct to return a property and its derivatives. As default, has the attributes val, and diffs. Implements
+    __setattr__ such that setting properties like
+        prop.something = ...
+    will also modify how __iter__ works, such that we can maintain compatibility with v2. This is done by maintaining
+    the self.__return_tuple__ and self.extra_optional_vals attributes, which hold extra values set on the object
+    after initialization. Thus, we can do
+        prop = Property(val, diffs, phase=2, apple='green')
+        value, dvdt, dvdp, phase, apple = prop # Expected from v2 return tuple (val, dvdt, dvdp, phase, apple)
+    or
+        prop = Property(val, diffs)
+        prop.phase = 2
+        prop.apple = 'green'
+        value, dvdt, dvdp, phase, apple = prop # Same behaviour as above
     """
-    def __init__(self, val, diffs):
+    def __init__(self, val, diffs, **kwargs):
         """Constructor
 
         Args:
             val (float or array_like) : The value of the property
             diffs (Differentials) : The derivatives
         """
-        self.diffs = diffs
+        self.__setting_optionals__ = False
         self.val = val
+        self.diffs = diffs
+        self.__return_tuple__ = (self.val, *[d for d in self.diffs])
 
-        if DIFFERENTIAL_RETURN_MODE == 'v2':
-            self.__return_tuple__ = (self.val,)
-            for d in self.diffs:
-                self.__return_tuple__ += (d,)
-        else:
-            self.__return_tuple__ = "There are no return tuples. Build with 'python makescript.py [optim/debug] -diffs=v2.1\n" \
-                                    "to use old style return tuples."
+        self.extra_optional_ids = []
+        self.extra_optional_vals = []
+        self.__dict__['__setting_optionals__'] = True
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
     @staticmethod
-    def from_return_tuple(return_tuple, flags, variables):
+    def from_return_tuple(return_tuple, flags, variables, **kwargs):
         """Constructor
         Construct a Property object from an "old-style" return_tuple, along with flags
 
@@ -301,7 +331,16 @@ class Property:
             Property : Constructed from the return_tuple
         """
         diffs = Differentials.from_return_tuple(return_tuple[1:], flags, variables)
-        return Property(return_tuple[0], diffs)
+        prop = Property(return_tuple[0], diffs, **kwargs)
+        return prop
+
+    def __setattr__(self, key, value):
+        self.__dict__[key] = value
+        if self.__setting_optionals__ is True:
+            self.extra_optional_ids.append(key)
+            self.extra_optional_vals.append(value)
+            self.__dict__['__return_tuple__'] += (value, )
+
 
     def __repr__(self):
         ostr = f'Property struct evaluated at constant ({self.diffs.constant})\n'
@@ -320,8 +359,8 @@ class Property:
         if DIFFERENTIAL_RETURN_MODE == 'v2':
             return (_ for _ in self.__return_tuple__)
         if self.diffs:
-            return (_ for _ in (self.val, self.diffs))
-        return (_ for _ in [self.val])
+            return (_ for _ in (self.val, self.diffs, *self.extra_optional_vals))
+        return (_ for _ in [self.val, *self.extra_optional_vals])
 
     def __getitem__(self, item):
         """
@@ -336,12 +375,9 @@ class Property:
         Ensure that ThermoPack methods can just `return Property.unpack()`, and then differentiating old-style vs.
         new-style is done here, rather than in every ThermoPack method.
         """
-        if self.diffs: # Correct packing for backwards compatibility handled in __iter__
+        # Backwards compatibility handled in __iter__
+        if self.diffs or self.extra_optional_vals or (DIFFERENTIAL_RETURN_MODE == 'v2'):
             return tuple(self.__iter__())
-
-        if DIFFERENTIAL_RETURN_MODE == 'v2':
-            return self.__return_tuple__
-
         return self.val
 
 def back_compatible_unpack(prop):


### PR DESCRIPTION
The `Property` struct can now hold extra optional variables, as used by `thermopack.thermo`, and the packing/unpacking routines for `Differential` and `Property` have been made more flexible with regard to how the structs can be constructed before returning them.