### PR TITLE
quantum cubic extension

### DIFF
--- a/binaries/PR_kij.json
+++ b/binaries/PR_kij.json
@@ -1960,20 +1960,62 @@
     "kij": 0.18
   },
   "vdW-281": {
+    "comp1": "O-H2",
+    "comp2": "D2",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.0
+  },
+  "vdW-282": {
+    "comp1": "O-H2",
+    "comp2": "NE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.18
+  },
+  "vdW-283": {
+    "comp1": "O-H2",
+    "comp2": "HE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.17
+  },
+    "vdW-284": {
+    "comp1": "P-H2",
+    "comp2": "D2",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.0
+  },
+  "vdW-285": {
+    "comp1": "P-H2",
+    "comp2": "NE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.18
+  },
+  "vdW-286": {
+    "comp1": "P-H2",
+    "comp2": "HE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "kij": 0.17
+  },
+  "vdW-287": {
     "comp1": "H2O2",
     "comp2": "H2O",
     "ref": "Default",
     "bib_reference": "",
     "kij":  -0.05
   },
-  "vdW-282": {
+  "vdW-288": {
     "comp1": "H2O2",
     "comp2": "O2",
     "ref": "tcPR-ENGINEERING",
     "bib_reference": "",
     "kij":  -0.75
   },
-  "vdW-283": {
+  "vdW-289": {
     "comp1": "H2O",
     "comp2": "O2",
     "ref": "tcPR-ENGINEERING",

--- a/binaries/PR_lij.json
+++ b/binaries/PR_lij.json
@@ -6,5 +6,21 @@
     "bib_reference": "10.1016/j.fluid.2020.112790",
     "mixing_rule": "vdW",
     "lij":  -0.16
+  },
+  "LIJ-2": {
+    "comp1": "O-H2",
+    "comp2": "HE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "mixing_rule": "vdW",
+    "lij": -0.16
+  },
+  "LIJ-3": {
+    "comp1": "P-H2",
+    "comp2": "HE",
+    "ref": "QuantumCubic",
+    "bib_reference": "10.1016/j.fluid.2020.112790",
+    "mixing_rule": "vdW",
+    "lij": -0.16
   }
 }

--- a/fluids/OrthoHydrogen.json
+++ b/fluids/OrthoHydrogen.json
@@ -83,7 +83,17 @@
     "bib_reference": ""
   },
   "SRK": {},
-  "PR": {},
+  "PR": {
+    "TWU-1": {
+      "ref": "QuantumCubic",
+      "bib_reference": "10.1016/j.fluid.2020.112790",
+      "correlation": [
+        156.21,
+        -0.0062072,
+        5.047
+      ]
+    }
+  },
     "SAFTVRMIE-1": {
     "m": 1.000,
     "sigma": 3.2571E-10,

--- a/fluids/ParaHydrogen.json
+++ b/fluids/ParaHydrogen.json
@@ -147,7 +147,17 @@
     ]
   },
   "SRK": {},
-  "PR": {},
+  "PR": {
+    "TWU-2": {
+      "ref": "QuantumCubic",
+      "bib_reference": "10.1016/j.fluid.2020.112790",
+      "correlation": [
+        156.21,
+        -0.0062072,
+        5.047
+      ]
+    }
+  },
   "SAFTVRMIE-1": {
     "m": 1.000,
     "sigma": 3.2557E-10,

--- a/src/cbbeta.f90
+++ b/src/cbbeta.f90
@@ -57,6 +57,10 @@ contains
              params = (/3.0696, 12.682/)
           else if (str_eq(comp(i)%p_comp%ident,"D2")) then
              params = (/1.6501, 7.309/)
+          else if (str_eq(comp(i)%p_comp%ident,"P-H2")) then
+             params = (/3.0710, 12.688/)
+          else if (str_eq(comp(i)%p_comp%ident,"O-H2")) then
+             params = (/3.0702, 12.684/)
           else
              params = (/0.0, 0.0/) ! Equivalent to beta(T)=1.0
           end if

--- a/src/compdatadb.f90
+++ b/src/compdatadb.f90
@@ -1,6 +1,6 @@
 !> Automatically generated to file compdatadb.f90
 !! using utility python code pyUtils
-!! Time stamp: 2024-06-21T11:24:33.132406
+!! Time stamp: 2024-10-28T15:26:42.069790
 
 module compdatadb
   use compdata, only: gendatadb, cpdata, alphadatadb, cidatadb, CPAdata
@@ -3851,6 +3851,13 @@ module compdatadb
       Tcpmax = 1000.0000  &
       )
 
+  type (alphadatadb), parameter :: twu82 = &
+      alphadatadb(eosid="PR", &
+      cid="O-H2", &
+      ref="QuantumCubic", &
+      coeff=(/1.56210000e+02, -6.20720000e-03, 5.04700000e+00/) &
+      )
+
   type (gendatadb), parameter :: cx50 = &
       gendatadb(ident = "OXYL", &
       formula = "C8H10", &
@@ -3890,7 +3897,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu82 = &
+  type (alphadatadb), parameter :: twu83 = &
       alphadatadb(eosid="PR", &
       cid="OXYL", &
       ref="tcPR", &
@@ -3908,7 +3915,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu83 = &
+  type (alphadatadb), parameter :: twu84 = &
       alphadatadb(eosid="SRK", &
       cid="OXYL", &
       ref="tcRK", &
@@ -3965,7 +3972,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu84 = &
+  type (alphadatadb), parameter :: twu85 = &
       alphadatadb(eosid="PR", &
       cid="O2", &
       ref="tcPR", &
@@ -3990,7 +3997,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu85 = &
+  type (alphadatadb), parameter :: twu86 = &
       alphadatadb(eosid="SRK", &
       cid="O2", &
       ref="tcRK", &
@@ -4054,6 +4061,13 @@ module compdatadb
       Tcpmax = 1000.0000  &
       )
 
+  type (alphadatadb), parameter :: twu87 = &
+      alphadatadb(eosid="PR", &
+      cid="P-H2", &
+      ref="QuantumCubic", &
+      coeff=(/1.56210000e+02, -6.20720000e-03, 5.04700000e+00/) &
+      )
+
   type (gendatadb), parameter :: cx53 = &
       gendatadb(ident = "PXYL", &
       formula = "C8H10", &
@@ -4093,7 +4107,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu86 = &
+  type (alphadatadb), parameter :: twu88 = &
       alphadatadb(eosid="PR", &
       cid="PXYL", &
       ref="tcPR", &
@@ -4111,7 +4125,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu87 = &
+  type (alphadatadb), parameter :: twu89 = &
       alphadatadb(eosid="SRK", &
       cid="PXYL", &
       ref="tcRK", &
@@ -4168,7 +4182,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu88 = &
+  type (alphadatadb), parameter :: twu90 = &
       alphadatadb(eosid="PR", &
       cid="C3", &
       ref="tcPR", &
@@ -4200,7 +4214,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu89 = &
+  type (alphadatadb), parameter :: twu91 = &
       alphadatadb(eosid="SRK", &
       cid="C3", &
       ref="tcRK", &
@@ -4286,7 +4300,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu90 = &
+  type (alphadatadb), parameter :: twu92 = &
       alphadatadb(eosid="PR", &
       cid="PRLN", &
       ref="tcPR", &
@@ -4304,7 +4318,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu91 = &
+  type (alphadatadb), parameter :: twu93 = &
       alphadatadb(eosid="SRK", &
       cid="PRLN", &
       ref="tcRK", &
@@ -4361,7 +4375,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu92 = &
+  type (alphadatadb), parameter :: twu94 = &
       alphadatadb(eosid="PR", &
       cid="R11", &
       ref="tcPR", &
@@ -4379,7 +4393,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu93 = &
+  type (alphadatadb), parameter :: twu95 = &
       alphadatadb(eosid="SRK", &
       cid="R11", &
       ref="tcRK", &
@@ -4436,7 +4450,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu94 = &
+  type (alphadatadb), parameter :: twu96 = &
       alphadatadb(eosid="PR", &
       cid="R1114", &
       ref="tcPR", &
@@ -4454,7 +4468,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu95 = &
+  type (alphadatadb), parameter :: twu97 = &
       alphadatadb(eosid="SRK", &
       cid="R1114", &
       ref="tcRK", &
@@ -4511,7 +4525,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu96 = &
+  type (alphadatadb), parameter :: twu98 = &
       alphadatadb(eosid="PR", &
       cid="R1132a", &
       ref="tcPR", &
@@ -4529,7 +4543,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu97 = &
+  type (alphadatadb), parameter :: twu99 = &
       alphadatadb(eosid="SRK", &
       cid="R1132a", &
       ref="tcRK", &
@@ -4586,7 +4600,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu98 = &
+  type (alphadatadb), parameter :: twu100 = &
       alphadatadb(eosid="PR", &
       cid="R114", &
       ref="tcPR", &
@@ -4604,7 +4618,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu99 = &
+  type (alphadatadb), parameter :: twu101 = &
       alphadatadb(eosid="SRK", &
       cid="R114", &
       ref="tcRK", &
@@ -4661,7 +4675,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu100 = &
+  type (alphadatadb), parameter :: twu102 = &
       alphadatadb(eosid="PR", &
       cid="R115", &
       ref="tcPR", &
@@ -4679,7 +4693,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu101 = &
+  type (alphadatadb), parameter :: twu103 = &
       alphadatadb(eosid="SRK", &
       cid="R115", &
       ref="tcRK", &
@@ -4736,7 +4750,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu102 = &
+  type (alphadatadb), parameter :: twu104 = &
       alphadatadb(eosid="PR", &
       cid="R116", &
       ref="tcPR", &
@@ -4754,7 +4768,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu103 = &
+  type (alphadatadb), parameter :: twu105 = &
       alphadatadb(eosid="SRK", &
       cid="R116", &
       ref="tcRK", &
@@ -4811,7 +4825,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu104 = &
+  type (alphadatadb), parameter :: twu106 = &
       alphadatadb(eosid="PR", &
       cid="R12", &
       ref="tcPR", &
@@ -4829,7 +4843,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu105 = &
+  type (alphadatadb), parameter :: twu107 = &
       alphadatadb(eosid="SRK", &
       cid="R12", &
       ref="tcRK", &
@@ -4886,7 +4900,7 @@ module compdatadb
       Tcpmax = 1000.0000  &
       )
 
-  type (alphadatadb), parameter :: twu106 = &
+  type (alphadatadb), parameter :: twu108 = &
       alphadatadb(eosid="PR", &
       cid="R1234yf", &
       ref="tcPR", &
@@ -4904,7 +4918,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu107 = &
+  type (alphadatadb), parameter :: twu109 = &
       alphadatadb(eosid="SRK", &
       cid="R1234yf", &
       ref="tcRK", &
@@ -4961,7 +4975,7 @@ module compdatadb
       Tcpmax = 500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu108 = &
+  type (alphadatadb), parameter :: twu110 = &
       alphadatadb(eosid="PR", &
       cid="R1234ze", &
       ref="tcPR", &
@@ -4979,7 +4993,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu109 = &
+  type (alphadatadb), parameter :: twu111 = &
       alphadatadb(eosid="SRK", &
       cid="R1234ze", &
       ref="tcRK", &
@@ -5036,7 +5050,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu110 = &
+  type (alphadatadb), parameter :: twu112 = &
       alphadatadb(eosid="PR", &
       cid="R124", &
       ref="tcPR", &
@@ -5054,7 +5068,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu111 = &
+  type (alphadatadb), parameter :: twu113 = &
       alphadatadb(eosid="SRK", &
       cid="R124", &
       ref="tcRK", &
@@ -5150,7 +5164,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu112 = &
+  type (alphadatadb), parameter :: twu114 = &
       alphadatadb(eosid="PR", &
       cid="R125", &
       ref="tcPR", &
@@ -5168,7 +5182,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu113 = &
+  type (alphadatadb), parameter :: twu115 = &
       alphadatadb(eosid="SRK", &
       cid="R125", &
       ref="tcRK", &
@@ -5225,7 +5239,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu114 = &
+  type (alphadatadb), parameter :: twu116 = &
       alphadatadb(eosid="PR", &
       cid="R13", &
       ref="tcPR", &
@@ -5243,7 +5257,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu115 = &
+  type (alphadatadb), parameter :: twu117 = &
       alphadatadb(eosid="SRK", &
       cid="R13", &
       ref="tcRK", &
@@ -5300,7 +5314,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu116 = &
+  type (alphadatadb), parameter :: twu118 = &
       alphadatadb(eosid="PR", &
       cid="R134a", &
       ref="tcPR", &
@@ -5318,7 +5332,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu117 = &
+  type (alphadatadb), parameter :: twu119 = &
       alphadatadb(eosid="SRK", &
       cid="R134a", &
       ref="tcRK", &
@@ -5375,7 +5389,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu118 = &
+  type (alphadatadb), parameter :: twu120 = &
       alphadatadb(eosid="PR", &
       cid="R14", &
       ref="tcPR", &
@@ -5393,7 +5407,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu119 = &
+  type (alphadatadb), parameter :: twu121 = &
       alphadatadb(eosid="SRK", &
       cid="R14", &
       ref="tcRK", &
@@ -5450,7 +5464,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu120 = &
+  type (alphadatadb), parameter :: twu122 = &
       alphadatadb(eosid="PR", &
       cid="R142b", &
       ref="tcPR", &
@@ -5468,7 +5482,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu121 = &
+  type (alphadatadb), parameter :: twu123 = &
       alphadatadb(eosid="SRK", &
       cid="R142b", &
       ref="tcRK", &
@@ -5525,7 +5539,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu122 = &
+  type (alphadatadb), parameter :: twu124 = &
       alphadatadb(eosid="PR", &
       cid="R143a", &
       ref="tcPR", &
@@ -5543,7 +5557,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu123 = &
+  type (alphadatadb), parameter :: twu125 = &
       alphadatadb(eosid="SRK", &
       cid="R143a", &
       ref="tcRK", &
@@ -5600,7 +5614,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu124 = &
+  type (alphadatadb), parameter :: twu126 = &
       alphadatadb(eosid="PR", &
       cid="R152a", &
       ref="tcPR", &
@@ -5618,7 +5632,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu125 = &
+  type (alphadatadb), parameter :: twu127 = &
       alphadatadb(eosid="SRK", &
       cid="R152a", &
       ref="tcRK", &
@@ -5675,7 +5689,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu126 = &
+  type (alphadatadb), parameter :: twu128 = &
       alphadatadb(eosid="PR", &
       cid="R21", &
       ref="tcPR", &
@@ -5693,7 +5707,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu127 = &
+  type (alphadatadb), parameter :: twu129 = &
       alphadatadb(eosid="SRK", &
       cid="R21", &
       ref="tcRK", &
@@ -5750,7 +5764,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu128 = &
+  type (alphadatadb), parameter :: twu130 = &
       alphadatadb(eosid="PR", &
       cid="R218", &
       ref="tcPR", &
@@ -5768,7 +5782,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu129 = &
+  type (alphadatadb), parameter :: twu131 = &
       alphadatadb(eosid="SRK", &
       cid="R218", &
       ref="tcRK", &
@@ -5825,7 +5839,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu130 = &
+  type (alphadatadb), parameter :: twu132 = &
       alphadatadb(eosid="PR", &
       cid="R22", &
       ref="tcPR", &
@@ -5843,7 +5857,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu131 = &
+  type (alphadatadb), parameter :: twu133 = &
       alphadatadb(eosid="SRK", &
       cid="R22", &
       ref="tcRK", &
@@ -5900,7 +5914,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu132 = &
+  type (alphadatadb), parameter :: twu134 = &
       alphadatadb(eosid="PR", &
       cid="R23", &
       ref="tcPR", &
@@ -5918,7 +5932,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu133 = &
+  type (alphadatadb), parameter :: twu135 = &
       alphadatadb(eosid="SRK", &
       cid="R23", &
       ref="tcRK", &
@@ -5975,7 +5989,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu134 = &
+  type (alphadatadb), parameter :: twu136 = &
       alphadatadb(eosid="PR", &
       cid="R32", &
       ref="tcPR", &
@@ -5993,7 +6007,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu135 = &
+  type (alphadatadb), parameter :: twu137 = &
       alphadatadb(eosid="SRK", &
       cid="R32", &
       ref="tcRK", &
@@ -6050,7 +6064,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu136 = &
+  type (alphadatadb), parameter :: twu138 = &
       alphadatadb(eosid="PR", &
       cid="R41", &
       ref="tcPR", &
@@ -6068,7 +6082,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu137 = &
+  type (alphadatadb), parameter :: twu139 = &
       alphadatadb(eosid="SRK", &
       cid="R41", &
       ref="tcRK", &
@@ -6125,7 +6139,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu138 = &
+  type (alphadatadb), parameter :: twu140 = &
       alphadatadb(eosid="PR", &
       cid="F6S", &
       ref="tcPR", &
@@ -6143,7 +6157,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu139 = &
+  type (alphadatadb), parameter :: twu141 = &
       alphadatadb(eosid="SRK", &
       cid="F6S", &
       ref="tcRK", &
@@ -6200,7 +6214,7 @@ module compdatadb
       Tcpmax = 1000.0000  &
       )
 
-  type (alphadatadb), parameter :: twu140 = &
+  type (alphadatadb), parameter :: twu142 = &
       alphadatadb(eosid="PR", &
       cid="SO2", &
       ref="tcPR", &
@@ -6218,7 +6232,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu141 = &
+  type (alphadatadb), parameter :: twu143 = &
       alphadatadb(eosid="SRK", &
       cid="SO2", &
       ref="tcRK", &
@@ -6275,7 +6289,7 @@ module compdatadb
       Tcpmax = 0.0000  &
       )
 
-  type (alphadatadb), parameter :: twu142 = &
+  type (alphadatadb), parameter :: twu144 = &
       alphadatadb(eosid="PR", &
       cid="F4N2", &
       ref="tcPR", &
@@ -6293,7 +6307,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu143 = &
+  type (alphadatadb), parameter :: twu145 = &
       alphadatadb(eosid="SRK", &
       cid="F4N2", &
       ref="tcRK", &
@@ -6357,7 +6371,7 @@ module compdatadb
       coeff=(/7.62000000e-01, -4.20000000e-02, 2.71000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu144 = &
+  type (alphadatadb), parameter :: twu146 = &
       alphadatadb(eosid="PR", &
       cid="TOLU", &
       ref="tcPR", &
@@ -6382,7 +6396,7 @@ module compdatadb
       coeff=(/9.23000000e-01, -3.01000000e-01, 4.94000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu145 = &
+  type (alphadatadb), parameter :: twu147 = &
       alphadatadb(eosid="SRK", &
       cid="TOLU", &
       ref="tcRK", &
@@ -6478,14 +6492,14 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu146 = &
+  type (alphadatadb), parameter :: twu148 = &
       alphadatadb(eosid="PR", &
       cid="H2O", &
       ref="tcPR", &
       coeff=(/3.86500000e-01, 8.72000000e-01, 1.96930000e+00/) &
       )
 
-  type (alphadatadb), parameter :: twu147 = &
+  type (alphadatadb), parameter :: twu149 = &
       alphadatadb(eosid="PR", &
       cid="H2O", &
       ref="Aasen2024", &
@@ -6532,7 +6546,7 @@ module compdatadb
       c_type=2 &
       )
 
-  type (alphadatadb), parameter :: twu148 = &
+  type (alphadatadb), parameter :: twu150 = &
       alphadatadb(eosid="SRK", &
       cid="H2O", &
       ref="tcRK", &
@@ -6694,7 +6708,7 @@ module compdatadb
       coeff=(/6.77000000e-01, -8.10000000e-02, 2.99000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu149 = &
+  type (alphadatadb), parameter :: twu151 = &
       alphadatadb(eosid="PR", &
       cid="NC4", &
       ref="tcPR", &
@@ -6726,7 +6740,7 @@ module compdatadb
       coeff=(/8.23000000e-01, -2.67000000e-01, 4.02000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu150 = &
+  type (alphadatadb), parameter :: twu152 = &
       alphadatadb(eosid="SRK", &
       cid="NC4", &
       ref="tcRK", &
@@ -6798,7 +6812,7 @@ module compdatadb
       Tcpmax = 700.0000  &
       )
 
-  type (alphadatadb), parameter :: twu151 = &
+  type (alphadatadb), parameter :: twu153 = &
       alphadatadb(eosid="PR", &
       cid="NC10", &
       ref="tcPR", &
@@ -6816,7 +6830,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu152 = &
+  type (alphadatadb), parameter :: twu154 = &
       alphadatadb(eosid="SRK", &
       cid="NC10", &
       ref="tcRK", &
@@ -6888,7 +6902,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu153 = &
+  type (alphadatadb), parameter :: twu155 = &
       alphadatadb(eosid="PR", &
       cid="NC22", &
       ref="tcPR", &
@@ -6906,7 +6920,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu154 = &
+  type (alphadatadb), parameter :: twu156 = &
       alphadatadb(eosid="SRK", &
       cid="NC22", &
       ref="tcRK", &
@@ -6963,7 +6977,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu155 = &
+  type (alphadatadb), parameter :: twu157 = &
       alphadatadb(eosid="PR", &
       cid="NC12", &
       ref="tcPR", &
@@ -6981,7 +6995,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu156 = &
+  type (alphadatadb), parameter :: twu158 = &
       alphadatadb(eosid="SRK", &
       cid="NC12", &
       ref="tcRK", &
@@ -7038,7 +7052,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu157 = &
+  type (alphadatadb), parameter :: twu159 = &
       alphadatadb(eosid="PR", &
       cid="NC20", &
       ref="tcPR", &
@@ -7056,7 +7070,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu158 = &
+  type (alphadatadb), parameter :: twu160 = &
       alphadatadb(eosid="SRK", &
       cid="NC20", &
       ref="tcRK", &
@@ -7113,7 +7127,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu159 = &
+  type (alphadatadb), parameter :: twu161 = &
       alphadatadb(eosid="PR", &
       cid="NC21", &
       ref="tcPR", &
@@ -7131,7 +7145,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu160 = &
+  type (alphadatadb), parameter :: twu162 = &
       alphadatadb(eosid="SRK", &
       cid="NC21", &
       ref="tcRK", &
@@ -7188,7 +7202,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu161 = &
+  type (alphadatadb), parameter :: twu163 = &
       alphadatadb(eosid="PR", &
       cid="NC17", &
       ref="tcPR", &
@@ -7206,7 +7220,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu162 = &
+  type (alphadatadb), parameter :: twu164 = &
       alphadatadb(eosid="SRK", &
       cid="NC17", &
       ref="tcRK", &
@@ -7277,7 +7291,7 @@ module compdatadb
       coeff=(/8.78000000e-01, -3.10000000e-02, 3.02000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu163 = &
+  type (alphadatadb), parameter :: twu165 = &
       alphadatadb(eosid="PR", &
       cid="NC7", &
       ref="tcPR", &
@@ -7309,7 +7323,7 @@ module compdatadb
       coeff=(/1.03600000e+00, -2.58000000e-01, 4.88000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu164 = &
+  type (alphadatadb), parameter :: twu166 = &
       alphadatadb(eosid="SRK", &
       cid="NC7", &
       ref="tcRK", &
@@ -7394,7 +7408,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu165 = &
+  type (alphadatadb), parameter :: twu167 = &
       alphadatadb(eosid="PR", &
       cid="NC16", &
       ref="tcPR", &
@@ -7412,7 +7426,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu166 = &
+  type (alphadatadb), parameter :: twu168 = &
       alphadatadb(eosid="SRK", &
       cid="NC16", &
       ref="tcRK", &
@@ -7483,7 +7497,7 @@ module compdatadb
       coeff=(/8.70000000e-01, -5.88000000e-01, 1.50400000e+00/) &
       )
 
-  type (alphadatadb), parameter :: twu167 = &
+  type (alphadatadb), parameter :: twu169 = &
       alphadatadb(eosid="PR", &
       cid="NC6", &
       ref="tcPR", &
@@ -7515,7 +7529,7 @@ module compdatadb
       coeff=(/1.00500000e+00, -5.91000000e-01, 1.20300000e+00/) &
       )
 
-  type (alphadatadb), parameter :: twu168 = &
+  type (alphadatadb), parameter :: twu170 = &
       alphadatadb(eosid="SRK", &
       cid="NC6", &
       ref="tcRK", &
@@ -7587,7 +7601,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu169 = &
+  type (alphadatadb), parameter :: twu171 = &
       alphadatadb(eosid="PR", &
       cid="NC19", &
       ref="tcPR", &
@@ -7605,7 +7619,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu170 = &
+  type (alphadatadb), parameter :: twu172 = &
       alphadatadb(eosid="SRK", &
       cid="NC19", &
       ref="tcRK", &
@@ -7662,7 +7676,7 @@ module compdatadb
       Tcpmax = 700.0000  &
       )
 
-  type (alphadatadb), parameter :: twu171 = &
+  type (alphadatadb), parameter :: twu173 = &
       alphadatadb(eosid="PR", &
       cid="NC9", &
       ref="tcPR", &
@@ -7680,7 +7694,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu172 = &
+  type (alphadatadb), parameter :: twu174 = &
       alphadatadb(eosid="SRK", &
       cid="NC9", &
       ref="tcRK", &
@@ -7752,7 +7766,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu173 = &
+  type (alphadatadb), parameter :: twu175 = &
       alphadatadb(eosid="PR", &
       cid="NC18", &
       ref="tcPR", &
@@ -7770,7 +7784,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu174 = &
+  type (alphadatadb), parameter :: twu176 = &
       alphadatadb(eosid="SRK", &
       cid="NC18", &
       ref="tcRK", &
@@ -7841,7 +7855,7 @@ module compdatadb
       coeff=(/9.58000000e-01, -1.34000000e-01, 4.87000000e-01/) &
       )
 
-  type (alphadatadb), parameter :: twu175 = &
+  type (alphadatadb), parameter :: twu177 = &
       alphadatadb(eosid="PR", &
       cid="NC8", &
       ref="tcPR", &
@@ -7873,7 +7887,7 @@ module compdatadb
       coeff=(/1.15000000e+00, -5.87000000e-01, 1.09600000e+00/) &
       )
 
-  type (alphadatadb), parameter :: twu176 = &
+  type (alphadatadb), parameter :: twu178 = &
       alphadatadb(eosid="SRK", &
       cid="NC8", &
       ref="tcRK", &
@@ -7945,7 +7959,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu177 = &
+  type (alphadatadb), parameter :: twu179 = &
       alphadatadb(eosid="PR", &
       cid="NC25", &
       ref="tcPR", &
@@ -7963,7 +7977,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu178 = &
+  type (alphadatadb), parameter :: twu180 = &
       alphadatadb(eosid="SRK", &
       cid="NC25", &
       ref="tcRK", &
@@ -8020,7 +8034,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu179 = &
+  type (alphadatadb), parameter :: twu181 = &
       alphadatadb(eosid="PR", &
       cid="NC15", &
       ref="tcPR", &
@@ -8038,7 +8052,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu180 = &
+  type (alphadatadb), parameter :: twu182 = &
       alphadatadb(eosid="SRK", &
       cid="NC15", &
       ref="tcRK", &
@@ -8177,7 +8191,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu181 = &
+  type (alphadatadb), parameter :: twu183 = &
       alphadatadb(eosid="PR", &
       cid="NC14", &
       ref="tcPR", &
@@ -8195,7 +8209,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu182 = &
+  type (alphadatadb), parameter :: twu184 = &
       alphadatadb(eosid="SRK", &
       cid="NC14", &
       ref="tcRK", &
@@ -8252,7 +8266,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu183 = &
+  type (alphadatadb), parameter :: twu185 = &
       alphadatadb(eosid="PR", &
       cid="NC24", &
       ref="tcPR", &
@@ -8270,7 +8284,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu184 = &
+  type (alphadatadb), parameter :: twu186 = &
       alphadatadb(eosid="SRK", &
       cid="NC24", &
       ref="tcRK", &
@@ -8327,7 +8341,7 @@ module compdatadb
       Tcpmax = 1500.0000  &
       )
 
-  type (alphadatadb), parameter :: twu185 = &
+  type (alphadatadb), parameter :: twu187 = &
       alphadatadb(eosid="PR", &
       cid="NC23", &
       ref="tcPR", &
@@ -8345,7 +8359,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu186 = &
+  type (alphadatadb), parameter :: twu188 = &
       alphadatadb(eosid="SRK", &
       cid="NC23", &
       ref="tcRK", &
@@ -8402,7 +8416,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu187 = &
+  type (alphadatadb), parameter :: twu189 = &
       alphadatadb(eosid="PR", &
       cid="NC13", &
       ref="tcPR", &
@@ -8420,7 +8434,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu188 = &
+  type (alphadatadb), parameter :: twu190 = &
       alphadatadb(eosid="SRK", &
       cid="NC13", &
       ref="tcRK", &
@@ -8477,7 +8491,7 @@ module compdatadb
       Tcpmax = 1200.0000  &
       )
 
-  type (alphadatadb), parameter :: twu189 = &
+  type (alphadatadb), parameter :: twu191 = &
       alphadatadb(eosid="PR", &
       cid="NC11", &
       ref="tcPR", &
@@ -8495,7 +8509,7 @@ module compdatadb
       c_type=1 &
       )
 
-  type (alphadatadb), parameter :: twu190 = &
+  type (alphadatadb), parameter :: twu192 = &
       alphadatadb(eosid="SRK", &
       cid="NC11", &
       ref="tcRK", &
@@ -8606,7 +8620,7 @@ module compdatadb
       cp111 &
   /)
 
-  integer, parameter :: maxTWUdb =190
+  integer, parameter :: maxTWUdb =192
   type (alphadatadb), dimension(maxTWUdb), parameter :: alphaTWUdb = (/&
       twu1,twu2,twu3,twu4,twu5, &
       twu6,twu7,twu8,twu9,twu10, &
@@ -8645,7 +8659,8 @@ module compdatadb
       twu171,twu172,twu173,twu174,twu175, &
       twu176,twu177,twu178,twu179,twu180, &
       twu181,twu182,twu183,twu184,twu185, &
-      twu186,twu187,twu188,twu189,twu190 &
+      twu186,twu187,twu188,twu189,twu190, &
+      twu191,twu192 &
   /)
 
   integer, parameter :: maxMCdb =65

--- a/src/eoslibinit.f90
+++ b/src/eoslibinit.f90
@@ -352,6 +352,9 @@ contains
       beta_loc = "Quantum"
       do i=1,nc
         ! Set critical parameters according to Aasen et al. (10.1016/j.fluid.2020.112790)
+        ! Note that the critical parameters are not the same as the ones listed in Table I
+        ! of the paper, which has slightly wrong values for for H2 and Ne. However, they do
+        ! correspond to the values used in the reference EoS cited in Table I.
         if (str_eq(complist(i),"HE")) then
           act_mod_ptr%comps(i)%p_comp%tc = 5.1953
           act_mod_ptr%comps(i)%p_comp%pc = 2.276e5
@@ -368,6 +371,16 @@ contains
           act_mod_ptr%comps(i)%p_comp%tc = 38.34
           act_mod_ptr%comps(i)%p_comp%pc = 16.796e5
           act_mod_ptr%comps(i)%p_comp%mw = 4.0282
+        ! These H2 isomers were not included in the original paper
+        ! For these we use the same parameters as Leachman et al. (10.1063/1.3160306)
+        else if (str_eq(complist(i),"O-H2")) then
+          act_mod_ptr%comps(i)%p_comp%tc = 33.22
+          act_mod_ptr%comps(i)%p_comp%pc = 13.1065e5
+          act_mod_ptr%comps(i)%p_comp%mw = 2.01594
+        else if (str_eq(complist(i),"P-H2")) then
+          act_mod_ptr%comps(i)%p_comp%tc = 32.938
+          act_mod_ptr%comps(i)%p_comp%pc = 12.858e5
+          act_mod_ptr%comps(i)%p_comp%mw = 2.01588
         end if
       enddo
     endif

--- a/src/eoslibinit.f90
+++ b/src/eoslibinit.f90
@@ -355,15 +355,19 @@ contains
         if (str_eq(complist(i),"HE")) then
           act_mod_ptr%comps(i)%p_comp%tc = 5.1953
           act_mod_ptr%comps(i)%p_comp%pc = 2.276e5
+          act_mod_ptr%comps(i)%p_comp%mw = 4.002602
         else if (str_eq(complist(i),"H2")) then
-          act_mod_ptr%comps(i)%p_comp%tc = 33.19
+          act_mod_ptr%comps(i)%p_comp%tc = 33.145
           act_mod_ptr%comps(i)%p_comp%pc = 12.964e5
+          act_mod_ptr%comps(i)%p_comp%mw = 2.01588
         else if (str_eq(complist(i),"Ne")) then
-          act_mod_ptr%comps(i)%p_comp%tc = 44.492
-          act_mod_ptr%comps(i)%p_comp%pc = 26.79e5
+          act_mod_ptr%comps(i)%p_comp%tc = 44.4
+          act_mod_ptr%comps(i)%p_comp%pc = 2661630.8085948555
+          act_mod_ptr%comps(i)%p_comp%mw = 20.179
         else if (str_eq(complist(i),"D2")) then
           act_mod_ptr%comps(i)%p_comp%tc = 38.34
           act_mod_ptr%comps(i)%p_comp%pc = 16.796e5
+          act_mod_ptr%comps(i)%p_comp%mw = 4.0282
         end if
       enddo
     endif

--- a/src/mixdatadb.f90
+++ b/src/mixdatadb.f90
@@ -1,6 +1,6 @@
 !> Automatically generated to file mixdatadb.f90
 !! using utility python code pyUtils
-!! Time stamp: 2024-02-01T17:13:14.588949
+!! Time stamp: 2024-10-30T12:54:21.245300
 
 module mixdatadb
   use cubic_eos, only: kijdatadb, interGEdatadb, lijdatadb, CPAkijdata
@@ -5591,6 +5591,66 @@ module mixdatadb
   type (kijdatadb), parameter :: vdw559 = &
       kijdatadb(eosid = "PR", &
       mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "O-H2", &
+      uid2 = "D2", &
+      kijvalue = 0.00000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw560 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "O-H2", &
+      uid2 = "NE", &
+      kijvalue = 0.18000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw561 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "O-H2", &
+      uid2 = "HE", &
+      kijvalue = 0.17000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw562 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "P-H2", &
+      uid2 = "D2", &
+      kijvalue = 0.00000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw563 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "P-H2", &
+      uid2 = "NE", &
+      kijvalue = 0.18000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw564 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "P-H2", &
+      uid2 = "HE", &
+      kijvalue = 0.17000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw565 = &
+      kijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
       ref = "Default", &
       bib_ref = "", &
       uid1 = "H2O2", &
@@ -5598,7 +5658,7 @@ module mixdatadb
       kijvalue = -0.05000000  &
       )
 
-  type (kijdatadb), parameter :: vdw560 = &
+  type (kijdatadb), parameter :: vdw566 = &
       kijdatadb(eosid = "PR", &
       mruleid = "vdW", &
       ref = "tcPR-ENGINEERING", &
@@ -5608,7 +5668,7 @@ module mixdatadb
       kijvalue = -0.75000000  &
       )
 
-  type (kijdatadb), parameter :: vdw561 = &
+  type (kijdatadb), parameter :: vdw567 = &
       kijdatadb(eosid = "PR", &
       mruleid = "vdW", &
       ref = "tcPR-ENGINEERING", &
@@ -5618,7 +5678,7 @@ module mixdatadb
       kijvalue = -0.26000000  &
       )
 
-  type (kijdatadb), parameter :: vdw562 = &
+  type (kijdatadb), parameter :: vdw568 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5628,7 +5688,7 @@ module mixdatadb
       kijvalue = 0.00500000  &
       )
 
-  type (kijdatadb), parameter :: vdw563 = &
+  type (kijdatadb), parameter :: vdw569 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5638,7 +5698,7 @@ module mixdatadb
       kijvalue = -0.00800000  &
       )
 
-  type (kijdatadb), parameter :: vdw564 = &
+  type (kijdatadb), parameter :: vdw570 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5648,7 +5708,7 @@ module mixdatadb
       kijvalue = 0.01500000  &
       )
 
-  type (kijdatadb), parameter :: vdw565 = &
+  type (kijdatadb), parameter :: vdw571 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5658,7 +5718,7 @@ module mixdatadb
       kijvalue = 0.02000000  &
       )
 
-  type (kijdatadb), parameter :: vdw566 = &
+  type (kijdatadb), parameter :: vdw572 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5668,7 +5728,7 @@ module mixdatadb
       kijvalue = 0.01000000  &
       )
 
-  type (kijdatadb), parameter :: vdw567 = &
+  type (kijdatadb), parameter :: vdw573 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5678,7 +5738,7 @@ module mixdatadb
       kijvalue = 0.00600000  &
       )
 
-  type (kijdatadb), parameter :: vdw568 = &
+  type (kijdatadb), parameter :: vdw574 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5688,7 +5748,7 @@ module mixdatadb
       kijvalue = 0.00400000  &
       )
 
-  type (kijdatadb), parameter :: vdw569 = &
+  type (kijdatadb), parameter :: vdw575 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5698,7 +5758,7 @@ module mixdatadb
       kijvalue = 0.00100000  &
       )
 
-  type (kijdatadb), parameter :: vdw570 = &
+  type (kijdatadb), parameter :: vdw576 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5708,7 +5768,7 @@ module mixdatadb
       kijvalue = -0.00100000  &
       )
 
-  type (kijdatadb), parameter :: vdw571 = &
+  type (kijdatadb), parameter :: vdw577 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5718,7 +5778,7 @@ module mixdatadb
       kijvalue = -0.01500000  &
       )
 
-  type (kijdatadb), parameter :: vdw572 = &
+  type (kijdatadb), parameter :: vdw578 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5728,7 +5788,7 @@ module mixdatadb
       kijvalue = 0.02600000  &
       )
 
-  type (kijdatadb), parameter :: vdw573 = &
+  type (kijdatadb), parameter :: vdw579 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5738,7 +5798,7 @@ module mixdatadb
       kijvalue = 0.01800000  &
       )
 
-  type (kijdatadb), parameter :: vdw574 = &
+  type (kijdatadb), parameter :: vdw580 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5748,7 +5808,7 @@ module mixdatadb
       kijvalue = 0.01900000  &
       )
 
-  type (kijdatadb), parameter :: vdw575 = &
+  type (kijdatadb), parameter :: vdw581 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5758,7 +5818,7 @@ module mixdatadb
       kijvalue = 0.06200000  &
       )
 
-  type (kijdatadb), parameter :: vdw576 = &
+  type (kijdatadb), parameter :: vdw582 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5768,7 +5828,7 @@ module mixdatadb
       kijvalue = 0.01300000  &
       )
 
-  type (kijdatadb), parameter :: vdw577 = &
+  type (kijdatadb), parameter :: vdw583 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5778,7 +5838,7 @@ module mixdatadb
       kijvalue = 0.01300000  &
       )
 
-  type (kijdatadb), parameter :: vdw578 = &
+  type (kijdatadb), parameter :: vdw584 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5788,7 +5848,7 @@ module mixdatadb
       kijvalue = 0.02100000  &
       )
 
-  type (kijdatadb), parameter :: vdw579 = &
+  type (kijdatadb), parameter :: vdw585 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5798,7 +5858,7 @@ module mixdatadb
       kijvalue = 0.03000000  &
       )
 
-  type (kijdatadb), parameter :: vdw580 = &
+  type (kijdatadb), parameter :: vdw586 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5808,7 +5868,7 @@ module mixdatadb
       kijvalue = 0.00500000  &
       )
 
-  type (kijdatadb), parameter :: vdw581 = &
+  type (kijdatadb), parameter :: vdw587 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5818,7 +5878,7 @@ module mixdatadb
       kijvalue = -0.00300000  &
       )
 
-  type (kijdatadb), parameter :: vdw582 = &
+  type (kijdatadb), parameter :: vdw588 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5828,7 +5888,7 @@ module mixdatadb
       kijvalue = 0.09300000  &
       )
 
-  type (kijdatadb), parameter :: vdw583 = &
+  type (kijdatadb), parameter :: vdw589 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5838,7 +5898,7 @@ module mixdatadb
       kijvalue = 0.12800000  &
       )
 
-  type (kijdatadb), parameter :: vdw584 = &
+  type (kijdatadb), parameter :: vdw590 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5848,7 +5908,7 @@ module mixdatadb
       kijvalue = 0.05700000  &
       )
 
-  type (kijdatadb), parameter :: vdw585 = &
+  type (kijdatadb), parameter :: vdw591 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5858,7 +5918,7 @@ module mixdatadb
       kijvalue = 0.13100000  &
       )
 
-  type (kijdatadb), parameter :: vdw586 = &
+  type (kijdatadb), parameter :: vdw592 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5868,7 +5928,7 @@ module mixdatadb
       kijvalue = 0.10900000  &
       )
 
-  type (kijdatadb), parameter :: vdw587 = &
+  type (kijdatadb), parameter :: vdw593 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5878,7 +5938,7 @@ module mixdatadb
       kijvalue = 0.12700000  &
       )
 
-  type (kijdatadb), parameter :: vdw588 = &
+  type (kijdatadb), parameter :: vdw594 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5888,7 +5948,7 @@ module mixdatadb
       kijvalue = 0.13500000  &
       )
 
-  type (kijdatadb), parameter :: vdw589 = &
+  type (kijdatadb), parameter :: vdw595 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5898,7 +5958,7 @@ module mixdatadb
       kijvalue = 0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw590 = &
+  type (kijdatadb), parameter :: vdw596 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5908,7 +5968,7 @@ module mixdatadb
       kijvalue = 0.08900000  &
       )
 
-  type (kijdatadb), parameter :: vdw591 = &
+  type (kijdatadb), parameter :: vdw597 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5918,7 +5978,7 @@ module mixdatadb
       kijvalue = 0.04600000  &
       )
 
-  type (kijdatadb), parameter :: vdw592 = &
+  type (kijdatadb), parameter :: vdw598 = &
       kijdatadb(eosid = "PT", &
       mruleid = "vdW", &
       ref = "Patel1982", &
@@ -5928,7 +5988,7 @@ module mixdatadb
       kijvalue = 0.05300000  &
       )
 
-  type (kijdatadb), parameter :: vdw593 = &
+  type (kijdatadb), parameter :: vdw599 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5938,7 +5998,7 @@ module mixdatadb
       kijvalue = -0.00780000  &
       )
 
-  type (kijdatadb), parameter :: vdw594 = &
+  type (kijdatadb), parameter :: vdw600 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5948,7 +6008,7 @@ module mixdatadb
       kijvalue = 0.02000000  &
       )
 
-  type (kijdatadb), parameter :: vdw595 = &
+  type (kijdatadb), parameter :: vdw601 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5958,7 +6018,7 @@ module mixdatadb
       kijvalue = 0.00900000  &
       )
 
-  type (kijdatadb), parameter :: vdw596 = &
+  type (kijdatadb), parameter :: vdw602 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5968,7 +6028,7 @@ module mixdatadb
       kijvalue = 0.02410000  &
       )
 
-  type (kijdatadb), parameter :: vdw597 = &
+  type (kijdatadb), parameter :: vdw603 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5978,7 +6038,7 @@ module mixdatadb
       kijvalue = 0.00560000  &
       )
 
-  type (kijdatadb), parameter :: vdw598 = &
+  type (kijdatadb), parameter :: vdw604 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5988,7 +6048,7 @@ module mixdatadb
       kijvalue = 0.01900000  &
       )
 
-  type (kijdatadb), parameter :: vdw599 = &
+  type (kijdatadb), parameter :: vdw605 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -5998,7 +6058,7 @@ module mixdatadb
       kijvalue = 0.09100000  &
       )
 
-  type (kijdatadb), parameter :: vdw600 = &
+  type (kijdatadb), parameter :: vdw606 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6008,7 +6068,7 @@ module mixdatadb
       kijvalue = 0.01120000  &
       )
 
-  type (kijdatadb), parameter :: vdw601 = &
+  type (kijdatadb), parameter :: vdw607 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6018,7 +6078,7 @@ module mixdatadb
       kijvalue = -0.00220000  &
       )
 
-  type (kijdatadb), parameter :: vdw602 = &
+  type (kijdatadb), parameter :: vdw608 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6028,7 +6088,7 @@ module mixdatadb
       kijvalue = -0.01000000  &
       )
 
-  type (kijdatadb), parameter :: vdw603 = &
+  type (kijdatadb), parameter :: vdw609 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6038,7 +6098,7 @@ module mixdatadb
       kijvalue = 0.00670000  &
       )
 
-  type (kijdatadb), parameter :: vdw604 = &
+  type (kijdatadb), parameter :: vdw610 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6048,7 +6108,7 @@ module mixdatadb
       kijvalue = 0.00560000  &
       )
 
-  type (kijdatadb), parameter :: vdw605 = &
+  type (kijdatadb), parameter :: vdw611 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6058,7 +6118,7 @@ module mixdatadb
       kijvalue = 0.10000000  &
       )
 
-  type (kijdatadb), parameter :: vdw606 = &
+  type (kijdatadb), parameter :: vdw612 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6068,7 +6128,7 @@ module mixdatadb
       kijvalue = -0.01000000  &
       )
 
-  type (kijdatadb), parameter :: vdw607 = &
+  type (kijdatadb), parameter :: vdw613 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6078,7 +6138,7 @@ module mixdatadb
       kijvalue = 0.02300000  &
       )
 
-  type (kijdatadb), parameter :: vdw608 = &
+  type (kijdatadb), parameter :: vdw614 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6088,7 +6148,7 @@ module mixdatadb
       kijvalue = 0.00110000  &
       )
 
-  type (kijdatadb), parameter :: vdw609 = &
+  type (kijdatadb), parameter :: vdw615 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6098,7 +6158,7 @@ module mixdatadb
       kijvalue = 0.02040000  &
       )
 
-  type (kijdatadb), parameter :: vdw610 = &
+  type (kijdatadb), parameter :: vdw616 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6108,7 +6168,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw611 = &
+  type (kijdatadb), parameter :: vdw617 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6118,7 +6178,7 @@ module mixdatadb
       kijvalue = -0.06300000  &
       )
 
-  type (kijdatadb), parameter :: vdw612 = &
+  type (kijdatadb), parameter :: vdw618 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6128,7 +6188,7 @@ module mixdatadb
       kijvalue = 0.05000000  &
       )
 
-  type (kijdatadb), parameter :: vdw613 = &
+  type (kijdatadb), parameter :: vdw619 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6138,7 +6198,7 @@ module mixdatadb
       kijvalue = 0.10400000  &
       )
 
-  type (kijdatadb), parameter :: vdw614 = &
+  type (kijdatadb), parameter :: vdw620 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6148,7 +6208,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw615 = &
+  type (kijdatadb), parameter :: vdw621 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6158,7 +6218,7 @@ module mixdatadb
       kijvalue = 0.00400000  &
       )
 
-  type (kijdatadb), parameter :: vdw616 = &
+  type (kijdatadb), parameter :: vdw622 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6168,7 +6228,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw617 = &
+  type (kijdatadb), parameter :: vdw623 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6178,7 +6238,7 @@ module mixdatadb
       kijvalue = -0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw618 = &
+  type (kijdatadb), parameter :: vdw624 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6188,73 +6248,13 @@ module mixdatadb
       kijvalue = 0.09500000  &
       )
 
-  type (kijdatadb), parameter :: vdw619 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "C2", &
-      kijvalue = 0.15000000  &
-      )
-
-  type (kijdatadb), parameter :: vdw620 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "C2_1", &
-      kijvalue = 0.15000000  &
-      )
-
-  type (kijdatadb), parameter :: vdw621 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "C3", &
-      kijvalue = 0.15000000  &
-      )
-
-  type (kijdatadb), parameter :: vdw622 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "H2O", &
-      kijvalue = 0.07400000  &
-      )
-
-  type (kijdatadb), parameter :: vdw623 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "IC4", &
-      kijvalue = 0.15000000  &
-      )
-
-  type (kijdatadb), parameter :: vdw624 = &
-      kijdatadb(eosid = "SRK", &
-      mruleid = "vdW", &
-      ref = "Default", &
-      bib_ref = "", &
-      uid1 = "CO2", &
-      uid2 = "IC5", &
-      kijvalue = 0.15000000  &
-      )
-
   type (kijdatadb), parameter :: vdw625 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
       bib_ref = "", &
       uid1 = "CO2", &
-      uid2 = "NC10", &
+      uid2 = "C2", &
       kijvalue = 0.15000000  &
       )
 
@@ -6264,7 +6264,7 @@ module mixdatadb
       ref = "Default", &
       bib_ref = "", &
       uid1 = "CO2", &
-      uid2 = "NC11", &
+      uid2 = "C2_1", &
       kijvalue = 0.15000000  &
       )
 
@@ -6274,7 +6274,7 @@ module mixdatadb
       ref = "Default", &
       bib_ref = "", &
       uid1 = "CO2", &
-      uid2 = "NC4", &
+      uid2 = "C3", &
       kijvalue = 0.15000000  &
       )
 
@@ -6284,11 +6284,71 @@ module mixdatadb
       ref = "Default", &
       bib_ref = "", &
       uid1 = "CO2", &
+      uid2 = "H2O", &
+      kijvalue = 0.07400000  &
+      )
+
+  type (kijdatadb), parameter :: vdw629 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
+      uid2 = "IC4", &
+      kijvalue = 0.15000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw630 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
+      uid2 = "IC5", &
+      kijvalue = 0.15000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw631 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
+      uid2 = "NC10", &
+      kijvalue = 0.15000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw632 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
+      uid2 = "NC11", &
+      kijvalue = 0.15000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw633 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
+      uid2 = "NC4", &
+      kijvalue = 0.15000000  &
+      )
+
+  type (kijdatadb), parameter :: vdw634 = &
+      kijdatadb(eosid = "SRK", &
+      mruleid = "vdW", &
+      ref = "Default", &
+      bib_ref = "", &
+      uid1 = "CO2", &
       uid2 = "NC5", &
       kijvalue = 0.15000000  &
       )
 
-  type (kijdatadb), parameter :: vdw629 = &
+  type (kijdatadb), parameter :: vdw635 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6298,7 +6358,7 @@ module mixdatadb
       kijvalue = 0.10000000  &
       )
 
-  type (kijdatadb), parameter :: vdw630 = &
+  type (kijdatadb), parameter :: vdw636 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6308,7 +6368,7 @@ module mixdatadb
       kijvalue = -0.05100000  &
       )
 
-  type (kijdatadb), parameter :: vdw631 = &
+  type (kijdatadb), parameter :: vdw637 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6318,7 +6378,7 @@ module mixdatadb
       kijvalue = 0.08800000  &
       )
 
-  type (kijdatadb), parameter :: vdw632 = &
+  type (kijdatadb), parameter :: vdw638 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6328,7 +6388,7 @@ module mixdatadb
       kijvalue = 0.07100000  &
       )
 
-  type (kijdatadb), parameter :: vdw633 = &
+  type (kijdatadb), parameter :: vdw639 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6338,7 +6398,7 @@ module mixdatadb
       kijvalue = 0.00900000  &
       )
 
-  type (kijdatadb), parameter :: vdw634 = &
+  type (kijdatadb), parameter :: vdw640 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6348,7 +6408,7 @@ module mixdatadb
       kijvalue = 0.06000000  &
       )
 
-  type (kijdatadb), parameter :: vdw635 = &
+  type (kijdatadb), parameter :: vdw641 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6358,7 +6418,7 @@ module mixdatadb
       kijvalue = 0.06000000  &
       )
 
-  type (kijdatadb), parameter :: vdw636 = &
+  type (kijdatadb), parameter :: vdw642 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6368,7 +6428,7 @@ module mixdatadb
       kijvalue = 0.05000000  &
       )
 
-  type (kijdatadb), parameter :: vdw637 = &
+  type (kijdatadb), parameter :: vdw643 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6378,7 +6438,7 @@ module mixdatadb
       kijvalue = 0.04000000  &
       )
 
-  type (kijdatadb), parameter :: vdw638 = &
+  type (kijdatadb), parameter :: vdw644 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6388,7 +6448,7 @@ module mixdatadb
       kijvalue = 0.04000000  &
       )
 
-  type (kijdatadb), parameter :: vdw639 = &
+  type (kijdatadb), parameter :: vdw645 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6398,7 +6458,7 @@ module mixdatadb
       kijvalue = 0.03000000  &
       )
 
-  type (kijdatadb), parameter :: vdw640 = &
+  type (kijdatadb), parameter :: vdw646 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6408,7 +6468,7 @@ module mixdatadb
       kijvalue = 0.01700000  &
       )
 
-  type (kijdatadb), parameter :: vdw641 = &
+  type (kijdatadb), parameter :: vdw647 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6418,7 +6478,7 @@ module mixdatadb
       kijvalue = 0.03400000  &
       )
 
-  type (kijdatadb), parameter :: vdw642 = &
+  type (kijdatadb), parameter :: vdw648 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6428,7 +6488,7 @@ module mixdatadb
       kijvalue = 0.06000000  &
       )
 
-  type (kijdatadb), parameter :: vdw643 = &
+  type (kijdatadb), parameter :: vdw649 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6438,7 +6498,7 @@ module mixdatadb
       kijvalue = 0.07500000  &
       )
 
-  type (kijdatadb), parameter :: vdw644 = &
+  type (kijdatadb), parameter :: vdw650 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6448,7 +6508,7 @@ module mixdatadb
       kijvalue = 0.09000000  &
       )
 
-  type (kijdatadb), parameter :: vdw645 = &
+  type (kijdatadb), parameter :: vdw651 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6458,7 +6518,7 @@ module mixdatadb
       kijvalue = 0.11300000  &
       )
 
-  type (kijdatadb), parameter :: vdw646 = &
+  type (kijdatadb), parameter :: vdw652 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6468,7 +6528,7 @@ module mixdatadb
       kijvalue = 0.08700000  &
       )
 
-  type (kijdatadb), parameter :: vdw647 = &
+  type (kijdatadb), parameter :: vdw653 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6478,7 +6538,7 @@ module mixdatadb
       kijvalue = 0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw648 = &
+  type (kijdatadb), parameter :: vdw654 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6488,7 +6548,7 @@ module mixdatadb
       kijvalue = 0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw649 = &
+  type (kijdatadb), parameter :: vdw655 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6498,7 +6558,7 @@ module mixdatadb
       kijvalue = 0.11300000  &
       )
 
-  type (kijdatadb), parameter :: vdw650 = &
+  type (kijdatadb), parameter :: vdw656 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6508,7 +6568,7 @@ module mixdatadb
       kijvalue = 0.14000000  &
       )
 
-  type (kijdatadb), parameter :: vdw651 = &
+  type (kijdatadb), parameter :: vdw657 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6518,7 +6578,7 @@ module mixdatadb
       kijvalue = 0.15000000  &
       )
 
-  type (kijdatadb), parameter :: vdw652 = &
+  type (kijdatadb), parameter :: vdw658 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6528,7 +6588,7 @@ module mixdatadb
       kijvalue = 0.14200000  &
       )
 
-  type (kijdatadb), parameter :: vdw653 = &
+  type (kijdatadb), parameter :: vdw659 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6538,7 +6598,7 @@ module mixdatadb
       kijvalue = 0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw654 = &
+  type (kijdatadb), parameter :: vdw660 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6548,7 +6608,7 @@ module mixdatadb
       kijvalue = 0.08000000  &
       )
 
-  type (kijdatadb), parameter :: vdw655 = &
+  type (kijdatadb), parameter :: vdw661 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6558,7 +6618,7 @@ module mixdatadb
       kijvalue = -0.01100000  &
       )
 
-  type (kijdatadb), parameter :: vdw656 = &
+  type (kijdatadb), parameter :: vdw662 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6568,7 +6628,7 @@ module mixdatadb
       kijvalue = 0.00540000  &
       )
 
-  type (kijdatadb), parameter :: vdw657 = &
+  type (kijdatadb), parameter :: vdw663 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6578,7 +6638,7 @@ module mixdatadb
       kijvalue = 0.00150000  &
       )
 
-  type (kijdatadb), parameter :: vdw658 = &
+  type (kijdatadb), parameter :: vdw664 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6588,7 +6648,7 @@ module mixdatadb
       kijvalue = 0.08670000  &
       )
 
-  type (kijdatadb), parameter :: vdw659 = &
+  type (kijdatadb), parameter :: vdw665 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6598,7 +6658,7 @@ module mixdatadb
       kijvalue = 0.02620000  &
       )
 
-  type (kijdatadb), parameter :: vdw660 = &
+  type (kijdatadb), parameter :: vdw666 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6608,7 +6668,7 @@ module mixdatadb
       kijvalue = 0.02990000  &
       )
 
-  type (kijdatadb), parameter :: vdw661 = &
+  type (kijdatadb), parameter :: vdw667 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6618,7 +6678,7 @@ module mixdatadb
       kijvalue = 0.03040000  &
       )
 
-  type (kijdatadb), parameter :: vdw662 = &
+  type (kijdatadb), parameter :: vdw668 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6628,7 +6688,7 @@ module mixdatadb
       kijvalue = 0.10080000  &
       )
 
-  type (kijdatadb), parameter :: vdw663 = &
+  type (kijdatadb), parameter :: vdw669 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6638,7 +6698,7 @@ module mixdatadb
       kijvalue = 0.04660000  &
       )
 
-  type (kijdatadb), parameter :: vdw664 = &
+  type (kijdatadb), parameter :: vdw670 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6648,7 +6708,7 @@ module mixdatadb
       kijvalue = 0.03990000  &
       )
 
-  type (kijdatadb), parameter :: vdw665 = &
+  type (kijdatadb), parameter :: vdw671 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6658,7 +6718,7 @@ module mixdatadb
       kijvalue = 0.05640000  &
       )
 
-  type (kijdatadb), parameter :: vdw666 = &
+  type (kijdatadb), parameter :: vdw672 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6668,7 +6728,7 @@ module mixdatadb
       kijvalue = 0.00570000  &
       )
 
-  type (kijdatadb), parameter :: vdw667 = &
+  type (kijdatadb), parameter :: vdw673 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6678,7 +6738,7 @@ module mixdatadb
       kijvalue = 0.08900000  &
       )
 
-  type (kijdatadb), parameter :: vdw668 = &
+  type (kijdatadb), parameter :: vdw674 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6688,7 +6748,7 @@ module mixdatadb
       kijvalue = 0.10320000  &
       )
 
-  type (kijdatadb), parameter :: vdw669 = &
+  type (kijdatadb), parameter :: vdw675 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6698,7 +6758,7 @@ module mixdatadb
       kijvalue = 0.12000000  &
       )
 
-  type (kijdatadb), parameter :: vdw670 = &
+  type (kijdatadb), parameter :: vdw676 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6708,7 +6768,7 @@ module mixdatadb
       kijvalue = -0.01110000  &
       )
 
-  type (kijdatadb), parameter :: vdw671 = &
+  type (kijdatadb), parameter :: vdw677 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6718,7 +6778,7 @@ module mixdatadb
       kijvalue = -0.00240000  &
       )
 
-  type (kijdatadb), parameter :: vdw672 = &
+  type (kijdatadb), parameter :: vdw678 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6728,7 +6788,7 @@ module mixdatadb
       kijvalue = 0.00130000  &
       )
 
-  type (kijdatadb), parameter :: vdw673 = &
+  type (kijdatadb), parameter :: vdw679 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6738,7 +6798,7 @@ module mixdatadb
       kijvalue = 0.03740000  &
       )
 
-  type (kijdatadb), parameter :: vdw674 = &
+  type (kijdatadb), parameter :: vdw680 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6748,7 +6808,7 @@ module mixdatadb
       kijvalue = 0.03070000  &
       )
 
-  type (kijdatadb), parameter :: vdw675 = &
+  type (kijdatadb), parameter :: vdw681 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6758,7 +6818,7 @@ module mixdatadb
       kijvalue = 0.04480000  &
       )
 
-  type (kijdatadb), parameter :: vdw676 = &
+  type (kijdatadb), parameter :: vdw682 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6768,7 +6828,7 @@ module mixdatadb
       kijvalue = -0.00780000  &
       )
 
-  type (kijdatadb), parameter :: vdw677 = &
+  type (kijdatadb), parameter :: vdw683 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6778,7 +6838,7 @@ module mixdatadb
       kijvalue = -0.00220000  &
       )
 
-  type (kijdatadb), parameter :: vdw678 = &
+  type (kijdatadb), parameter :: vdw684 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6788,7 +6848,7 @@ module mixdatadb
       kijvalue = 0.07600000  &
       )
 
-  type (kijdatadb), parameter :: vdw679 = &
+  type (kijdatadb), parameter :: vdw685 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6798,7 +6858,7 @@ module mixdatadb
       kijvalue = 0.53000000  &
       )
 
-  type (kijdatadb), parameter :: vdw680 = &
+  type (kijdatadb), parameter :: vdw686 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6808,7 +6868,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw681 = &
+  type (kijdatadb), parameter :: vdw687 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6818,7 +6878,7 @@ module mixdatadb
       kijvalue = 0.00440000  &
       )
 
-  type (kijdatadb), parameter :: vdw682 = &
+  type (kijdatadb), parameter :: vdw688 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6828,7 +6888,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw683 = &
+  type (kijdatadb), parameter :: vdw689 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6838,7 +6898,7 @@ module mixdatadb
       kijvalue = 0.00780000  &
       )
 
-  type (kijdatadb), parameter :: vdw684 = &
+  type (kijdatadb), parameter :: vdw690 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6848,7 +6908,7 @@ module mixdatadb
       kijvalue = -0.01560000  &
       )
 
-  type (kijdatadb), parameter :: vdw685 = &
+  type (kijdatadb), parameter :: vdw691 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6858,7 +6918,7 @@ module mixdatadb
       kijvalue = 0.11200000  &
       )
 
-  type (kijdatadb), parameter :: vdw686 = &
+  type (kijdatadb), parameter :: vdw692 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6868,7 +6928,7 @@ module mixdatadb
       kijvalue = 0.50000000  &
       )
 
-  type (kijdatadb), parameter :: vdw687 = &
+  type (kijdatadb), parameter :: vdw693 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6878,7 +6938,7 @@ module mixdatadb
       kijvalue = -0.01110000  &
       )
 
-  type (kijdatadb), parameter :: vdw688 = &
+  type (kijdatadb), parameter :: vdw694 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6888,7 +6948,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw689 = &
+  type (kijdatadb), parameter :: vdw695 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6898,7 +6958,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw690 = &
+  type (kijdatadb), parameter :: vdw696 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6908,7 +6968,7 @@ module mixdatadb
       kijvalue = -0.00110000  &
       )
 
-  type (kijdatadb), parameter :: vdw691 = &
+  type (kijdatadb), parameter :: vdw697 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6918,7 +6978,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw692 = &
+  type (kijdatadb), parameter :: vdw698 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6928,7 +6988,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw693 = &
+  type (kijdatadb), parameter :: vdw699 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6938,7 +6998,7 @@ module mixdatadb
       kijvalue = 0.08500000  &
       )
 
-  type (kijdatadb), parameter :: vdw694 = &
+  type (kijdatadb), parameter :: vdw700 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6948,7 +7008,7 @@ module mixdatadb
       kijvalue = 0.55000000  &
       )
 
-  type (kijdatadb), parameter :: vdw695 = &
+  type (kijdatadb), parameter :: vdw701 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6958,7 +7018,7 @@ module mixdatadb
       kijvalue = 0.00410000  &
       )
 
-  type (kijdatadb), parameter :: vdw696 = &
+  type (kijdatadb), parameter :: vdw702 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6968,7 +7028,7 @@ module mixdatadb
       kijvalue = 0.01700000  &
       )
 
-  type (kijdatadb), parameter :: vdw697 = &
+  type (kijdatadb), parameter :: vdw703 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6978,7 +7038,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw698 = &
+  type (kijdatadb), parameter :: vdw704 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6988,7 +7048,7 @@ module mixdatadb
       kijvalue = 0.11000000  &
       )
 
-  type (kijdatadb), parameter :: vdw699 = &
+  type (kijdatadb), parameter :: vdw705 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -6998,7 +7058,7 @@ module mixdatadb
       kijvalue = 0.12000000  &
       )
 
-  type (kijdatadb), parameter :: vdw700 = &
+  type (kijdatadb), parameter :: vdw706 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7008,7 +7068,7 @@ module mixdatadb
       kijvalue = 0.17000000  &
       )
 
-  type (kijdatadb), parameter :: vdw701 = &
+  type (kijdatadb), parameter :: vdw707 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7018,7 +7078,7 @@ module mixdatadb
       kijvalue = 0.13500000  &
       )
 
-  type (kijdatadb), parameter :: vdw702 = &
+  type (kijdatadb), parameter :: vdw708 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7028,7 +7088,7 @@ module mixdatadb
       kijvalue = 0.06000000  &
       )
 
-  type (kijdatadb), parameter :: vdw703 = &
+  type (kijdatadb), parameter :: vdw709 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7038,7 +7098,7 @@ module mixdatadb
       kijvalue = 0.06500000  &
       )
 
-  type (kijdatadb), parameter :: vdw704 = &
+  type (kijdatadb), parameter :: vdw710 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7048,7 +7108,7 @@ module mixdatadb
       kijvalue = 0.53000000  &
       )
 
-  type (kijdatadb), parameter :: vdw705 = &
+  type (kijdatadb), parameter :: vdw711 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7058,7 +7118,7 @@ module mixdatadb
       kijvalue = 0.52000000  &
       )
 
-  type (kijdatadb), parameter :: vdw706 = &
+  type (kijdatadb), parameter :: vdw712 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7068,7 +7128,7 @@ module mixdatadb
       kijvalue = 0.52000000  &
       )
 
-  type (kijdatadb), parameter :: vdw707 = &
+  type (kijdatadb), parameter :: vdw713 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7078,7 +7138,7 @@ module mixdatadb
       kijvalue = 0.50000000  &
       )
 
-  type (kijdatadb), parameter :: vdw708 = &
+  type (kijdatadb), parameter :: vdw714 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7088,7 +7148,7 @@ module mixdatadb
       kijvalue = 0.50000000  &
       )
 
-  type (kijdatadb), parameter :: vdw709 = &
+  type (kijdatadb), parameter :: vdw715 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7098,7 +7158,7 @@ module mixdatadb
       kijvalue = 0.50000000  &
       )
 
-  type (kijdatadb), parameter :: vdw710 = &
+  type (kijdatadb), parameter :: vdw716 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7108,7 +7168,7 @@ module mixdatadb
       kijvalue = 0.50000000  &
       )
 
-  type (kijdatadb), parameter :: vdw711 = &
+  type (kijdatadb), parameter :: vdw717 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7118,7 +7178,7 @@ module mixdatadb
       kijvalue = -0.00040000  &
       )
 
-  type (kijdatadb), parameter :: vdw712 = &
+  type (kijdatadb), parameter :: vdw718 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7128,7 +7188,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw713 = &
+  type (kijdatadb), parameter :: vdw719 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7138,7 +7198,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw714 = &
+  type (kijdatadb), parameter :: vdw720 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7148,7 +7208,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw715 = &
+  type (kijdatadb), parameter :: vdw721 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7158,7 +7218,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw716 = &
+  type (kijdatadb), parameter :: vdw722 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7168,7 +7228,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw717 = &
+  type (kijdatadb), parameter :: vdw723 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7178,7 +7238,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw718 = &
+  type (kijdatadb), parameter :: vdw724 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7188,7 +7248,7 @@ module mixdatadb
       kijvalue = 0.00190000  &
       )
 
-  type (kijdatadb), parameter :: vdw719 = &
+  type (kijdatadb), parameter :: vdw725 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7198,7 +7258,7 @@ module mixdatadb
       kijvalue = -0.00220000  &
       )
 
-  type (kijdatadb), parameter :: vdw720 = &
+  type (kijdatadb), parameter :: vdw726 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7208,7 +7268,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw721 = &
+  type (kijdatadb), parameter :: vdw727 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7218,7 +7278,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw722 = &
+  type (kijdatadb), parameter :: vdw728 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7228,7 +7288,7 @@ module mixdatadb
       kijvalue = 0.00000000  &
       )
 
-  type (kijdatadb), parameter :: vdw723 = &
+  type (kijdatadb), parameter :: vdw729 = &
       kijdatadb(eosid = "SRK", &
       mruleid = "vdW", &
       ref = "Default", &
@@ -7514,6 +7574,26 @@ module mixdatadb
       lijvalue = -0.16000000  &
       )
 
+  type (lijdatadb), parameter :: lij2 = &
+      lijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "O-H2", &
+      uid2 = "HE", &
+      lijvalue = -0.16000000  &
+      )
+
+  type (lijdatadb), parameter :: lij3 = &
+      lijdatadb(eosid = "PR", &
+      mruleid = "vdW", &
+      ref = "QuantumCubic", &
+      bib_ref = "10.1016/j.fluid.2020.112790", &
+      uid1 = "P-H2", &
+      uid2 = "HE", &
+      lijvalue = -0.16000000  &
+      )
+
   type(CPAkijdata), parameter :: cpa1 = &
       CPAkijdata(eosid = "CPA-SRK", &
       ref = "DEFAULT", &
@@ -7671,7 +7751,7 @@ module mixdatadb
       )
 
 
-  integer, parameter :: maxkij =723
+  integer, parameter :: maxkij =729
   type (kijdatadb), dimension(maxkij), parameter :: kijdb = (/&
       vdw1,vdw2,vdw3,vdw4,vdw5, &
       vdw6,vdw7,vdw8,vdw9,vdw10, &
@@ -7817,7 +7897,8 @@ module mixdatadb
       vdw706,vdw707,vdw708,vdw709,vdw710, &
       vdw711,vdw712,vdw713,vdw714,vdw715, &
       vdw716,vdw717,vdw718,vdw719,vdw720, &
-      vdw721,vdw722,vdw723 &
+      vdw721,vdw722,vdw723,vdw724,vdw725, &
+      vdw726,vdw727,vdw728,vdw729 &
   /)
 
   integer, parameter :: maxinterGEij =19
@@ -7828,9 +7909,9 @@ module mixdatadb
       ge16,ge17,ge18,ge19 &
   /)
 
-  integer, parameter :: maxlij =1
+  integer, parameter :: maxlij =3
   type (lijdatadb), dimension(maxlij), parameter :: lijdb = (/&
-      lij1 &
+      lij1,lij2,lij3 &
   /)
 
   integer, parameter :: CPAmaxkij =12

--- a/src/tuning.f90
+++ b/src/tuning.f90
@@ -267,7 +267,6 @@ subroutine thermopack_set_alpha_corr(numparam, i, corrname, c)
   alphaIdx = get_alpha_db_idx(corrname)
   select type(p_eos => act_eos_ptr)
   class is (cb_eos)
-    alphaIdx = p_eos%single(i)%alphaMethod
     call setSingleAlphaCorr(i, p_eos, alphaIdx=alphaIdx, alphaParams=c)
   class default
     print *,"thermopack_set_alpha_corr: Only for cubic eos"

--- a/unittests/test_quantumcubic.pf
+++ b/unittests/test_quantumcubic.pf
@@ -65,6 +65,31 @@ contains
     call specificVolume(T,P,n,VAPPH,V)
     @assertEqual(V, 3.3377514385725247E-004, 1e-11)
 
+    call init_quantum_cubic("O-H2,NE")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 0.27753807535682150E-3, 1e-11)
+
+    call init_quantum_cubic("O-H2,D2")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 2.6994400019876016E-004, 1e-11)
+
+    call init_quantum_cubic("HE,O-H2")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 0.33404549077092075E-3, 1e-11)
+     
+    call init_quantum_cubic("P-H2,NE")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 0.27781602389115784E-3, 1e-11)
+
+    call init_quantum_cubic("P-H2,D2")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 2.7024728684077909E-004, 1e-11)
+
+    call init_quantum_cubic("HE,P-H2")
+    call specificVolume(T,P,n,VAPPH,V)
+    @assertEqual(V, 0.33410614314059446E-3, 1e-11)
+
+
     ! Test numerical derivatives
     cbeos => get_active_eos()
     act_mod_ptr => get_active_thermo_model()

--- a/unittests/test_quantumcubic.pf
+++ b/unittests/test_quantumcubic.pf
@@ -43,19 +43,19 @@ contains
     ! Test state points
     call init_quantum_cubic("H2,NE")
     call specificVolume(T,P,n,VAPPH,V)
-    @assertEqual(V, 0.27635062506735163E-3, 1e-11)
+    @assertEqual(V, 0.27652353707155995E-3, 1e-11)
 
     call init_quantum_cubic("H2,D2")
     call specificVolume(T,P,n,VAPPH,V)
-    @assertEqual(V, 0.26869372000726689E-3, 1e-11)
+    @assertEqual(V, 2.6889954630757618E-004, 1e-11)
 
     call init_quantum_cubic("NE,D2")
     call specificVolume(T,P,n,VAPPH,V)
-    @assertEqual(V, 0.27071144987470875E-3, 1e-11)
+    @assertEqual(V, 0.27066747884535924E-3, 1e-11)
 
     call init_quantum_cubic("HE,NE")
     call specificVolume(T,P,n,VAPPH,V)
-    @assertEqual(V, 0.32864553263355610E-3, 1e-11)
+    @assertEqual(V, 0.32864422306179474E-3, 1e-11)
 
     call init_quantum_cubic("HE,D2")
     call specificVolume(T,P,n,VAPPH,V)
@@ -63,7 +63,7 @@ contains
 
     call init_quantum_cubic("HE,H2")
     call specificVolume(T,P,n,VAPPH,V)
-    @assertEqual(V, 0.33375935042262721E-3, 1e-11)
+    @assertEqual(V, 3.3377514385725247E-004, 1e-11)
 
     ! Test numerical derivatives
     cbeos => get_active_eos()


### PR DESCRIPTION
- Fix in set_alpha_corr
- Fix quantum cubic critical parameters for normal hydrogen and neon.
- Extend quantum cubic to ortho- and parahydrogen.
