### PR TITLE
Define c_len_type in volume_translation.py

### DIFF
--- a/addon/pycThermopack/thermopack/volume_translation.py
+++ b/addon/pycThermopack/thermopack/volume_translation.py
@@ -1,7 +1,7 @@
 # Import ctypes
 from ctypes import *
 import numpy as np
-from .thermo import thermo
+from .thermo import thermo, c_len_type
 
 
 class volume_translation(thermo):


### PR DESCRIPTION
Fix for an error that arose running eos.init_peneloux_volume_shift()