### PR TITLE
Exposing more stuff in property structs

### DIFF
--- a/addon/pycThermopack/map_platform_specifics.py
+++ b/addon/pycThermopack/map_platform_specifics.py
@@ -22,7 +22,7 @@ I_POSTFIX = "_"
 I_POSTFIX_NM = "_"
 
 VERSION_2 = '2.2.5b0'
-VERSION_3 = '3.b0'
+VERSION_3 = '3.0.0'
 pf_specifics_path = os.path.join(os.path.dirname( __file__), "thermopack", "platform_specifics.py")
 
 class bcolor:

--- a/addon/pycThermopack/thermopack/saft.py
+++ b/addon/pycThermopack/thermopack/saft.py
@@ -1,14 +1,8 @@
-# Import ctypes
 from ctypes import *
-# Importing Numpy (math, arrays, etc...)
 import numpy as np
 from . import utils
-# Import platform to detect OS
-from sys import platform, exit
-# Import os utils
-from os import path
-# Import thermo
-from .thermo import thermo, c_len_type
+from thermopack.utils import Property
+from .thermo import thermo
 
 
 class saft(thermo):
@@ -300,7 +294,7 @@ class saft(thermo):
 
         return_tuple = (a_c.value, )
         return_tuple = utils.fill_return_tuple(return_tuple, optional_ptrs, optional_flags, optional_arrayshapes)
-        return return_tuple
+        return Property.from_return_tuple(return_tuple, optional_flags, 'tvn').unpack()
 
     def a_hard_sphere(self, temp, volume, n, a_t=None, a_v=None, a_n=None, a_tt=None, a_vv=None,
                       a_tv=None, a_tn=None, a_vn=None, a_nn=None):

--- a/addon/pycThermopack/thermopack/utils.py
+++ b/addon/pycThermopack/thermopack/utils.py
@@ -234,7 +234,7 @@ class Differentials:
 
         Args:
             vals (tuple) : A (possibly empty) tuple of differentials.
-            flags (tuple) : The flags passed to the thermopack method (dxdt, dxdv, dxdn) or (dxdt, dxdp, dxdn).
+            flags (tuple | list) : The flags passed to the thermopack method (dxdt, dxdv, dxdn) or (dxdt, dxdp, dxdn).
             variables (str) : Key (either 'tvn' or 'tpn') indicating what differentials are expected in `vals`
 
         Returns:

--- a/addon/pycThermopack/thermopack/utils.py
+++ b/addon/pycThermopack/thermopack/utils.py
@@ -197,7 +197,7 @@ class Differentials:
             if len(diffs) == 3:
                 self.dT, self.dV, self.dn = diffs
             else:
-                self.dT, self.dV, self.dn, self.dTT, self.dVV, self.d_V, self.dTn, self.dVn, self.dnn = diffs
+                self.dT, self.dV, self.dn, self.dTT, self.dVV, self.dTV, self.dTn, self.dVn, self.dnn = diffs
         elif (self.constant == 'tpn') and (diffs is not None):
             self.dT, self.dp, self.dn = diffs
         elif diffs is not None:


### PR DESCRIPTION
Needed over in SurfPack.

Also, if we could merge #196 that would also be nice, SurfPack relies on the `dew_pressure` and `bubble_pressure` functions to generate adsorbtion isotherms and surface tension isotherms for mixtures, so getting that extra robustness would be very nice. Per now I regularly need to resort to "manually" solving for the saturation pressure, which is a bit annoying.